### PR TITLE
Check if vdb input is empty for OpenVDBReadNode

### DIFF
--- a/openvdb_maya/maya/OpenVDBReadNode.cc
+++ b/openvdb_maya/maya/OpenVDBReadNode.cc
@@ -129,6 +129,11 @@ MStatus OpenVDBReadNode::compute(const MPlug& plug, MDataBlock& data)
         MDataHandle filePathHandle = data.inputValue (aVdbFilePath, &status);
         if (status != MS::kSuccess) return status;
 
+        if( filePathHandle.asString().length() == 0 )
+        {
+            return MS::kFailure;
+        }
+
         std::ifstream ifile(filePathHandle.asString().asChar(), std::ios_base::binary);
         openvdb::GridPtrVecPtr grids = openvdb::io::Stream(ifile).getGrids();
 


### PR DESCRIPTION
This is a fix that will avoid Maya to crash if a user try to connect an OpenVDBRead node to a OpenVDBVisualize node without first setting VdbFilePath.