### PR TITLE
DuplicateSourceStealable

### DIFF
--- a/openvdb/CHANGES
+++ b/openvdb/CHANGES
@@ -21,12 +21,16 @@ Version 3.1.0 - In development
     - Extended the API of tools::Diagnose and disabled copy construction.
 
     Houdini:
-    - Added a Diagnostics SOP that performs validation tests on grids to 
+    - Added a Diagnostics SOP that performs validation tests on grids to
       detect potential issues. The tests are currently automated, but manual
       selections will be added soon.
     - Redesigned the UI of the Visualize SOP and added toggles to draw with
       or without color, to use the grid name as the attribute name for points
       with values, and to attach grid index coordinates to points.
+    - Added SOP_NodeVDB::duplicateSourceStealable() to avoid the cost of a
+      deep-copy when using Houdini's unload flag and updated the following SOPs:
+      Advect_Level_Set, Convert, Fill, Filter, Filter_Level_Set, Fracture, Noise,
+      Prune, Resample, Transform.
 
 Version 3.0.0 - January 14, 2014
     - The io::File class now supports delayed loading of .vdb files,

--- a/openvdb_houdini/houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.cc
@@ -165,14 +165,14 @@ SOP_NodeVDB::getNodeSpecificInfoText(OP_Context &context, OP_NodeInfoParms &parm
 
 ////////////////////////////////////////
 
+#if (UT_VERSION_INT >= 0x0d000000) // 13.0 or later
 OP_ERROR
 SOP_NodeVDB::duplicateSourceStealable(const unsigned index, OP_Context& context,
-                                      GU_Detail **pgdp, GU_DetailHandle& gdh, int clean,
-                                      GA_DataIdStrategy data_id_strategy)
+                                      GU_Detail **pgdp, GU_DetailHandle& gdh, bool clean)
 {
     // traverse upstream nodes, if unload is not possible, duplicate the source
     if (!isSourceStealable(index, context)) {
-        duplicateSource(index, context, *pgdp, clean, data_id_strategy);
+        duplicateSource(index, context, *pgdp, clean);
         unlockInput(index);
         return error();
     }
@@ -213,12 +213,6 @@ SOP_NodeVDB::duplicateSourceStealable(const unsigned index, OP_Context& context,
     return error();
 }
 
-OP_ERROR
-SOP_NodeVDB::duplicateSourceStealable(const unsigned index, OP_Context& context, int clean,
-                                      GA_DataIdStrategy data_id_strategy) {
-    return this->duplicateSourceStealable(index, context, &gdp, myGdpHandle, clean, data_id_strategy);
-}
-
 bool
 SOP_NodeVDB::isSourceStealable(const unsigned index, OP_Context& context) const
 {
@@ -253,7 +247,26 @@ SOP_NodeVDB::isSourceStealable(const unsigned index, OP_Context& context) const
 
     return false;
 }
+#else
+SOP_NodeVDB::duplicateSourceStealable(const unsigned index, OP_Context& context,
+                                      GU_Detail **pgdp, GU_DetailHandle& gdh, bool clean)
+{
+    duplicateSource(index, context, *pgdp, clean);
+    unlockInput(index);
+    return error();
+}
 
+bool
+SOP_NodeVDB::isSourceStealable(const unsigned index, OP_Context& context) const
+{
+    return false;
+}
+#endif
+
+OP_ERROR
+SOP_NodeVDB::duplicateSourceStealable(const unsigned index, OP_Context& context, bool clean) {
+    return this->duplicateSourceStealable(index, context, &gdp, myGdpHandle, clean);
+}
 
 ////////////////////////////////////////
 

--- a/openvdb_houdini/houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.cc
@@ -40,11 +40,14 @@
 #include <GU/GU_Detail.h>
 #include <GU/GU_PrimPoly.h>
 #include <OP/OP_NodeInfoParms.h>
-#include <SOP/SOP_Cache.h> // for stealable
 #include <PRM/PRM_Parm.h>
 #include <PRM/PRM_Type.h>
 #include <UT/UT_InfoTree.h>
 #include <sstream>
+
+#if (UT_VERSION_INT >= 0x0d000000) // 13.0 or later
+#include <SOP/SOP_Cache.h> // for stealable
+#endif
 
 namespace openvdb_houdini {
 
@@ -247,26 +250,19 @@ SOP_NodeVDB::isSourceStealable(const unsigned index, OP_Context& context) const
 
     return false;
 }
-#else
-SOP_NodeVDB::duplicateSourceStealable(const unsigned index, OP_Context& context,
-                                      GU_Detail **pgdp, GU_DetailHandle& gdh, bool clean)
-{
-    duplicateSource(index, context, *pgdp, clean);
-    unlockInput(index);
-    return error();
-}
-
-bool
-SOP_NodeVDB::isSourceStealable(const unsigned index, OP_Context& context) const
-{
-    return false;
-}
-#endif
 
 OP_ERROR
 SOP_NodeVDB::duplicateSourceStealable(const unsigned index, OP_Context& context, bool clean) {
     return this->duplicateSourceStealable(index, context, &gdp, myGdpHandle, clean);
 }
+#else
+OP_ERROR
+SOP_NodeVDB::duplicateSourceStealable(const unsigned index, OP_Context& context, bool clean) {
+    duplicateSource(index, context, gdp, clean);
+    unlockInput(index);
+    return error();
+}
+#endif
 
 ////////////////////////////////////////
 

--- a/openvdb_houdini/houdini/SOP_NodeVDB.h
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.h
@@ -43,6 +43,8 @@
 #include <UT/UT_DSOVersion.h>
 #endif
 
+#include <UT/UT_Version.h>
+
 class GU_Detail;
 
 namespace openvdb_houdini {
@@ -134,8 +136,10 @@ protected:
     ///
     /// @note No attempt to call duplicateSource() or inputGeo() should be made after calling this
     /// method, as there will be no data on the input stream if isSourceStealable() returns true
+#if (UT_VERSION_INT >= 0x0d000000) // 13.0 or later
     OP_ERROR duplicateSourceStealable(const unsigned index, OP_Context& context,
                                       GU_Detail **pgdp, GU_DetailHandle& gdh, bool clean=true);
+#endif
 
     OP_ERROR duplicateSourceStealable(const unsigned index, OP_Context& context, bool clean=true);
 
@@ -150,7 +154,9 @@ private:
     ///
     /// @param index    the index of the input from which to perform this operation
     /// @param context  the current SOP context is used for cook time for network traversal
+#if (UT_VERSION_INT >= 0x0d000000) // 13.0 or later
     bool isSourceStealable(const unsigned index, OP_Context& context) const;
+#endif
 };
 
 } // namespace openvdb_houdini

--- a/openvdb_houdini/houdini/SOP_NodeVDB.h
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.h
@@ -123,6 +123,7 @@ protected:
     /// the data. In certain cases where the geometry isn't being used elsewhere, the data can be
     /// explictly re-used to avoid the cost of a deep-copy when modifying the data. This method will
     /// insert the existing data into the gdp and update the gdp handle in the SOP.
+    /// (Disabled prior to H13)
     ///
     /// Reference counting of the Houdini VDB Primitive shared pointers ensures we cannot steal data
     /// in use elsewhere. If so, this method falls back to copying the shared pointer, effectively
@@ -134,11 +135,9 @@ protected:
     /// @note No attempt to call duplicateSource() or inputGeo() should be made after calling this
     /// method, as there will be no data on the input stream if isSourceStealable() returns true
     OP_ERROR duplicateSourceStealable(const unsigned index, OP_Context& context,
-                                      GU_Detail **pgdp, GU_DetailHandle& gdh, int clean=1,
-                                      GA_DataIdStrategy data_id_strategy = GA_DATA_ID_BUMP);
+                                      GU_Detail **pgdp, GU_DetailHandle& gdh, bool clean=true);
 
-    OP_ERROR duplicateSourceStealable(const unsigned index, OP_Context& context, int clean=1,
-                                      GA_DataIdStrategy data_id_strategy = GA_DATA_ID_BUMP);
+    OP_ERROR duplicateSourceStealable(const unsigned index, OP_Context& context, bool clean=true);
 
 private:
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Level_Set.cc
@@ -305,7 +305,7 @@ SOP_OpenVDB_Advect_Level_Set::cookMySop(OP_Context& context)
     try {
         hutil::ScopedInputLock lock(*this, context);
         gdp->clearAndDestroy();
-        duplicateSource(0, context);
+        duplicateSourceStealable(0, context);
 
         // Evaluate UI parameters
         AdvectionParms parms;

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Convert.cc
@@ -1310,7 +1310,7 @@ SOP_OpenVDB_Convert::cookMySop(OP_Context& context)
     try {
         hutil::ScopedInputLock lock(*this, context);
 
-        duplicateSource(0, context);
+        duplicateSourceStealable(0, context);
 
         const fpreal t = context.getTime();
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Fill.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Fill.cc
@@ -305,7 +305,7 @@ SOP_OpenVDB_Fill::cookMySop(OP_Context& context)
 
         const fpreal t = context.getTime();
 
-        duplicateSource(0, context);
+        duplicateSourceStealable(0, context);
 
         UT_String groupStr;
         evalString(groupStr, "group", 0, t);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Filter.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Filter.cc
@@ -506,7 +506,7 @@ SOP_OpenVDB_Filter::cookMySop(OP_Context& context)
 #else
         if (lock.lock(*startNode, context) >= UT_ERROR_ABORT) return error();
 #endif
-        if (startNode->duplicateSource(0, context, gdp) >= UT_ERROR_ABORT) return error();
+        if (startNode->duplicateSourceStealable(0, context) >= UT_ERROR_ABORT) return error();
 
         // Get the group of grids to process.
         UT_String groupStr;

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc
@@ -700,7 +700,7 @@ SOP_OpenVDB_Filter_Level_Set::cookMySop(OP_Context& context)
 #endif
 
         // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
-        if (startNode->duplicateSource(0, context, gdp) >= UT_ERROR_ABORT) return error();
+        if (startNode->duplicateSourceStealable(0, context) >= UT_ERROR_ABORT) return error();
 
         BossT boss("Processing level sets");
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Fracture.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Fracture.cc
@@ -229,7 +229,7 @@ SOP_OpenVDB_Fracture::cookMySop(OP_Context& context)
     try {
         hutil::ScopedInputLock lock(*this, context);
         const fpreal time = context.getTime();
-        duplicateSource(0, context);
+        duplicateSourceStealable(0, context);
 
         hvdb::Interrupter boss("Converting geometry to volume");
 
@@ -283,7 +283,9 @@ SOP_OpenVDB_Fracture::cookMySop(OP_Context& context)
 
             GU_PrimVDB* vdb = vdbIter.getPrimitive();
 
-            grids.push_back(vdb->getGrid().deepCopyGrid());
+            vdb->makeGridUnique();
+
+            grids.push_back(vdb->getGrid().copyGrid());
             grids.back()->setName(vdb->getGridName());
 
             grids.back()->insertMeta("houdiniorigoffset",

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Noise.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Noise.cc
@@ -463,7 +463,7 @@ SOP_OpenVDB_Noise::cookMySop(OP_Context &context)
         const fpreal time = context.getTime();
 
         // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
-        duplicateSource(0, context);
+        duplicateSourceStealable(0, context);
 
         // Evaluate the FractalBoltzman noise parameters from UI
         FractalBoltzmanGenerator fbGenerator(static_cast<float>(evalFloat("freq", 0, time)),

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Prune.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Prune.cc
@@ -183,7 +183,7 @@ SOP_OpenVDB_Prune::cookMySop(OP_Context& context)
 
         // This does a deep copy of native Houdini primitives
         // but only a shallow copy of OpenVDB grids.
-        duplicateSource(0, context);
+        duplicateSourceStealable(0, context);
 
         // Get the group of grids to process.
         UT_String groupStr;

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Resample.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Resample.cc
@@ -324,7 +324,7 @@ SOP_OpenVDB_Resample::cookMySop(OP_Context& context)
         const fpreal time = context.getTime();
 
         // This does a shallow copy of VDB grids and deep copy of native Houdini primitives.
-        duplicateSource(0, context);
+        duplicateSourceStealable(0, context);
 
         const GU_Detail* refGdp = inputGeo(1, context);
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Transform.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Transform.cc
@@ -156,7 +156,7 @@ SOP_OpenVDB_Transform::cookMySop(OP_Context& context)
         const fpreal time = context.getTime();
 
         // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
-        duplicateSource(0, context);
+        duplicateSourceStealable(0, context);
 
         // Get UI parameters
         openvdb::Vec3R t(evalVec3R("t", time)), r(evalVec3R("r", time)),
@@ -222,7 +222,7 @@ SOP_OpenVDB_Transform::cookMySop(OP_Context& context)
             {
                 // If (and only if) the grid is vector-valued, deep copy it,
                 // then apply the transform to each voxel's value.
-                GEOvdbProcessTypedGridVec3(*vdb, xformOp, /*makeUnique=*/true);
+                GEOvdbProcessTypedGridVec3(*vdb, xformOp);
             }
         }
     } catch (std::exception& e) {


### PR DESCRIPTION
Added SOP_NodeVDB::duplicateSourceStealable() to avoid the cost of a deep-copy when using Houdini's unload flag and updated the following SOPs:

Advect_Level_Set, Convert, Fill, Filter, Filter_Level_Set, Fracture, Noise, Prune, Resample, Transform.