### PR TITLE
glfw fix: request framebuffer size instead of window's

### DIFF
--- a/openvdb/viewer/Camera.cc
+++ b/openvdb/viewer/Camera.cc
@@ -129,7 +129,7 @@ Camera::aim()
     // Get the window size
     int width, height;
 #if GLFW_VERSION_MAJOR >= 3
-    glfwGetWindowSize(mWindow, &width, &height);
+    glfwGetFramebufferSize(mWindow, &width, &height);
 #else
     glfwGetWindowSize(&width, &height);
 #endif

--- a/openvdb/viewer/Viewer.cc
+++ b/openvdb/viewer/Viewer.cc
@@ -812,7 +812,7 @@ ViewerImpl::render()
 
         int width, height;
 #if GLFW_VERSION_MAJOR >= 3
-        glfwGetWindowSize(mWindow, &width, &height);
+        glfwGetFramebufferSize(mWindow, &width, &height);
 #else
         glfwGetWindowSize(&width, &height);
 #endif


### PR DESCRIPTION
In systems where the framebuffer and window sizes differ (such as on the OS X Mavericks and later), the framebuffer is the one we want. As it is, the viewport is about a quarter of the window size.