### PR TITLE
Add failure case of a union of a leaf and a tile

### DIFF
--- a/openvdb/unittest/TestTree.cc
+++ b/openvdb/unittest/TestTree.cc
@@ -1430,6 +1430,25 @@ TestTree::testTopologyUnion()
             ASSERT_DOUBLES_EXACTLY_EQUAL(tree0.getValue(p), *iter);
         }
     }
+    {// test union of a leaf and a tile
+
+        if (openvdb::FloatTree::DEPTH > 2) {
+
+            const openvdb::Coord xyz(0);
+
+            openvdb::FloatTree tree0;
+            const int leafLevel = openvdb::FloatTree::DEPTH - 1;
+            const int tileLevel = leafLevel - 1;
+            tree0.addTile(tileLevel, xyz, /*value=*/0, /*activeState=*/true);
+
+            openvdb::FloatTree tree1;
+            tree1.touchLeaf(xyz)->setValuesOn();
+
+            tree0.topologyUnion(tree1);
+
+            CPPUNIT_ASSERT_EQUAL(tree0.getValueDepth(xyz), leafLevel);
+        }
+    }
 
 }// testTopologyUnion
 

--- a/openvdb/unittest/TestTree.cc
+++ b/openvdb/unittest/TestTree.cc
@@ -1434,11 +1434,12 @@ TestTree::testTopologyUnion()
 
         if (openvdb::FloatTree::DEPTH > 2) {
 
+            const int leafLevel = openvdb::FloatTree::DEPTH - 1;
+            const int tileLevel = leafLevel - 1;
+
             const openvdb::Coord xyz(0);
 
             openvdb::FloatTree tree0;
-            const int leafLevel = openvdb::FloatTree::DEPTH - 1;
-            const int tileLevel = leafLevel - 1;
             tree0.addTile(tileLevel, xyz, /*value=*/0, /*activeState=*/true);
 
             openvdb::FloatTree tree1;


### PR DESCRIPTION
When building in debug mode, I get an assert firing during a topology union between a leaf and a tile:

```
../openvdb/tree/InternalNode.h:2358: openvdb::v3_1_0::tree::InternalNode<_ChildNodeType, Log2Dim>::TopologyUnion<OtherInternalNode>::TopologyUnion(const OtherInternalNode*, openvdb::v3_1_0::tree::InternalNode<_ChildNodeType, Log2Dim>*) [with OtherInternalNode = openvdb::v3_1_0::tree::InternalNode<openvdb::v3_1_0::tree::InternalNode<openvdb::v3_1_0::tree::LeafNode<float, 3u>, 4u>, 5u>, ChildT = openvdb::v3_1_0::tree::InternalNode<openvdb::v3_1_0::tree::LeafNode<float, 3u>, 4u>, unsigned int Log2Dim = 5u]: Assertion `(t->mValueMask&t->mChildMask).isOff()' failed.
```

This assert isn't present before the recent performance update commit. I have added a reproducing case to the unit tests, which passes when run before the performance update commit.

This pull request doesn't fix the issue, it just highlights it.