### PR TITLE
Viewer key fix

### DIFF
--- a/openvdb/viewer/Viewer.cc
+++ b/openvdb/viewer/Viewer.cc
@@ -1086,13 +1086,13 @@ ViewerImpl::keyCallback(int key, int action)
 
     if (keyPress) {
         switch (key) {
-        case '1':
+        case '1': case GLFW_KEY_KP_1:
             toggleRenderModule(0);
             break;
-        case '2':
+        case '2': case GLFW_KEY_KP_2:
             toggleRenderModule(1);
             break;
-        case '3':
+        case '3': case GLFW_KEY_KP_3:
             toggleRenderModule(2);
             break;
         case 'c': case 'C':


### PR DESCRIPTION
Number keys (numpad or not) are not recognized here unless I use the keys definitions set in GLFW.

For the record here's my setup:
- Linux Mint 17 64-bit
- GLFW version 2
- Keyboard set to "French - Latin 9"
