### PR TITLE
Compile fix: allow usage of float precision rays.

### DIFF
--- a/openvdb/math/Ray.h
+++ b/openvdb/math/Ray.h
@@ -54,9 +54,9 @@ class Ray
 {
 public:
     BOOST_STATIC_ASSERT(boost::is_floating_point<RealT>::value);
-    typedef RealT      RealType;
-    typedef Vec3<Real> Vec3Type;
-    typedef Vec3Type   Vec3T;
+    typedef RealT       RealType;
+    typedef Vec3<RealT> Vec3Type;
+    typedef Vec3Type    Vec3T;
     struct TimeSpan {
         RealT t0, t1;
         /// @brief Default constructor
@@ -160,7 +160,7 @@ public:
     inline Ray applyMap(const MapType& map) const
     {
         assert(map.isLinear());
-        assert(math::isApproxEqual(mDir.length(), RealT(1)));
+        assert(math::isRelOrApproxEqual(mDir.length(), RealT(1), Tolerance<RealT>::value(), Delta<RealT>::value()));
         const Vec3T eye = map.applyMap(mEye);
         const Vec3T dir = map.applyJacobian(mDir);
         const RealT length = dir.length();
@@ -177,7 +177,7 @@ public:
     inline Ray applyInverseMap(const MapType& map) const
     {
         assert(map.isLinear());
-        assert(math::isApproxEqual(mDir.length(), RealT(1)));
+        assert(math::isRelOrApproxEqual(mDir.length(), RealT(1), Tolerance<RealT>::value(), Delta<RealT>::value()));
         const Vec3T eye = map.applyInverseMap(mEye);
         const Vec3T dir = map.applyInverseJacobian(mDir);
         const RealT length = dir.length();

--- a/openvdb/tools/RayIntersector.h
+++ b/openvdb/tools/RayIntersector.h
@@ -151,7 +151,7 @@ public:
     /// @param iRay  ray represented in index space.
     /// @param iTime if an intersection was found it is assigned the time of the
     ///              intersection along the index ray.
-    bool intersectsIS(const RayType& iRay, Real &iTime) const
+    bool intersectsIS(const RayType& iRay, RealType &iTime) const
     {
         if (!mTester.setIndexRay(iRay)) return false;//missed bbox
         iTime = mTester.getIndexTime();
@@ -176,7 +176,7 @@ public:
     ///              intersection point in index space, otherwise it is unchanged.
     /// @param iTime if an intersection was found it is assigned the time of the
     ///              intersection along the index ray.
-    bool intersectsIS(const RayType& iRay, Vec3Type& xyz, Real &iTime) const
+    bool intersectsIS(const RayType& iRay, Vec3Type& xyz, RealType &iTime) const
     {
         if (!mTester.setIndexRay(iRay)) return false;//missed bbox
         if (!math::LevelSetHDDA<TreeT, NodeLevel>::test(mTester)) return false;//missed level set
@@ -197,7 +197,7 @@ public:
     /// @param wRay   ray represented in world space.
     /// @param wTime  if an intersection was found it is assigned the time of the
     ///               intersection along the world ray.
-    bool intersectsWS(const RayType& wRay, Real &wTime) const
+    bool intersectsWS(const RayType& wRay, RealType &wTime) const
     {
         if (!mTester.setWorldRay(wRay)) return false;//missed bbox
         wTime = mTester.getWorldTime();
@@ -222,7 +222,7 @@ public:
     ///               intersection point in world space, otherwise it is unchanged.
     /// @param wTime  if an intersection was found it is assigned the time of the
     ///               intersection along the world ray.
-    bool intersectsWS(const RayType& wRay, Vec3Type& world, Real &wTime) const
+    bool intersectsWS(const RayType& wRay, Vec3Type& world, RealType &wTime) const
     {
         if (!mTester.setWorldRay(wRay)) return false;//missed bbox
         if (!math::LevelSetHDDA<TreeT, NodeLevel>::test(mTester)) return false;//missed level set
@@ -253,7 +253,7 @@ public:
     ///               of the level set surface in world space, otherwise it is unchanged.
     /// @param wTime  if an intersection was found it is assigned the time of the
     ///               intersection along the world ray.
-    bool intersectsWS(const RayType& wRay, Vec3Type& world, Vec3Type& normal, Real &wTime) const
+    bool intersectsWS(const RayType& wRay, Vec3Type& world, Vec3Type& normal, RealType &wTime) const
     {
         if (!mTester.setWorldRay(wRay)) return false;//missed bbox
         if (!math::LevelSetHDDA<TreeT, NodeLevel>::test(mTester)) return false;//missed level set

--- a/openvdb/tools/RayIntersector.h
+++ b/openvdb/tools/RayIntersector.h
@@ -433,7 +433,7 @@ public:
     /// BBOX for the leaf nodes.
     /// @warning t0 and t1 are computed with repect to the ray represented in
     /// index space of the current grid, not world space!
-    inline bool march(Real& t0, Real& t1)
+    inline bool march(RealType& t0, RealType& t1)
     {
         const typename RayT::TimeSpan t = this->march();
         t.get(t0, t1);
@@ -456,13 +456,13 @@ public:
 
     /// @brief Return the floating-point index position along the
     /// current index ray at the specified time.
-    inline Vec3R getIndexPos(Real time) const { return mRay(time); }
+    inline Vec3R getIndexPos(RealType time) const { return mRay(time); }
 
     /// @brief Return the floating-point world position along the
     /// current index ray at the specified time.
-    inline Vec3R getWorldPos(Real time) const { return mGrid->indexToWorld(mRay(time)); }
+    inline Vec3R getWorldPos(RealType time) const { return mGrid->indexToWorld(mRay(time)); }
 
-    inline Real getWorldTime(Real time) const
+    inline RealType getWorldTime(RealType time) const
     {
         return time*mGrid->transform().baseMap()->applyJacobian(mRay.dir()).length();
     }
@@ -502,7 +502,7 @@ private:
     const GridT*    mGrid;
     AccessorT       mAccessor;
     RayT            mRay;
-    Real            mTmax;
+    RealType        mTmax;
     math::CoordBBox mBBox;
     math::VolumeHDDA<TreeT, RayType, NodeLevel> mHDDA;
 


### PR DESCRIPTION
It is currently impossible to compile client code making use of float precision rays, e.g. this code fails:

```
using namespace openvdb;
using namespace openvdb::math;
typedef Ray<float> RayType;
typedef tools::VolumeRayIntersector<FloatGrid,
                                                            FloatTree::RootNodeType::ChildNodeType::LEVEL,
                                                            RayType> IsectType;
```

This is mainly due to a misuse of the `RealT` or `RealType` template parameters and the globally defined `Real` typedef set to double, so some function called by the Ray or {Volume|LevelSet}RayIntersector classes would get different types whilst expecting a single type for all their parameters. For example `math::Min(T, T, T, T)` would get (float, double, double, double) when using float rays.

Also, one assert was failing in the Ray class when comparing floats, so `math::isRelOrApproxEqual` is used now.