### PR TITLE
Avoid using C++ built-in typeid keyword directly.

### DIFF
--- a/openvdb/Types.h
+++ b/openvdb/Types.h
@@ -264,7 +264,7 @@ enum MergePolicy {
 ////////////////////////////////////////
 
 
-template<typename T> const char* typeNameAsString()                 { return typeid(T).name(); }
+template<typename T> const char* typeNameAsString()                 { return BOOST_SP_TYPEID(T).name(); }
 template<> inline const char* typeNameAsString<bool>()              { return "bool"; }
 template<> inline const char* typeNameAsString<float>()             { return "float"; }
 template<> inline const char* typeNameAsString<double>()            { return "double"; }

--- a/openvdb/io/Archive.cc
+++ b/openvdb/io/Archive.cc
@@ -320,7 +320,7 @@ template<typename T>
 inline bool
 writeAsType(std::ostream& os, const boost::any& val)
 {
-    if (val.type() == typeid(T)) {
+    if (val.type() == BOOST_SP_TYPEID(T)) {
         os << boost::any_cast<T>(val);
         return true;
     }

--- a/openvdb/tree/RootNode.h
+++ b/openvdb/tree/RootNode.h
@@ -1097,8 +1097,8 @@ struct RootNodeCopyHelper
         self.enforceCompatibleValueTypes(other);
         // One of the above two tests should throw, so we should never get here:
         std::ostringstream ostr;
-        ostr << "cannot convert a " << typeid(OtherRootT).name()
-            << " to a " << typeid(RootT).name();
+        ostr << "cannot convert a " << BOOST_SP_TYPEID(OtherRootT).name()
+            << " to a " << BOOST_SP_TYPEID(RootT).name();
         OPENVDB_THROW(TypeError, ostr.str());
     }
 };
@@ -3144,8 +3144,8 @@ struct RootNodeCombineHelper
         self.enforceCompatibleValueTypes(other1);
         // One of the above two tests should throw, so we should never get here:
         std::ostringstream ostr;
-        ostr << "cannot combine a " << typeid(OtherRootT).name()
-            << " into a " << typeid(RootT).name();
+        ostr << "cannot combine a " << BOOST_SP_TYPEID(OtherRootT).name()
+            << " into a " << BOOST_SP_TYPEID(RootT).name();
         OPENVDB_THROW(TypeError, ostr.str());
     }
 };

--- a/openvdb/tree/Tree.h
+++ b/openvdb/tree/Tree.h
@@ -1748,7 +1748,7 @@ Tree<RootNodeType>::getBackgroundValue() const
     if (Metadata::isRegisteredType(valueType())) {
         typedef TypedMetadata<ValueType> MetadataT;
         result = Metadata::createMetadata(valueType());
-        if (MetadataT* m = dynamic_cast<MetadataT*>(result.get())) {
+        if (MetadataT* m = reinterpret_cast<MetadataT*>(result.get())) {
             m->value() = mRoot.background();
         }
     }


### PR DESCRIPTION
This set of changes is required for the integration of OpenVDB in the Cycles render engine, from the Blender Foundation.

We can't use C++'s built-in RTTI system in Cycles, due to LLVM being used to JIT compile OSL source code (OSL is used as a shading backend in Cycles). So the 'typeid' keyword was replaced with `BOOST_SP_TYPEID`. By default, it's using the 'typeid' keyword, so nothing really changes, and if `BOOST_NO_TYPEID` is defined (like in Cycles' case), it'll fall back to a custom implementation.

There's also a `dynamic_cast` which gives issues here, so I changed it to a `reinterpret_cast`, but I'm not too sure about that (it could be a simple `static_cast` by the looks of it).