### PR TITLE
Duplicate source stealable updates

### DIFF
--- a/openvdb_houdini/houdini/SOP_NodeVDB.h
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.h
@@ -117,7 +117,6 @@ protected:
     void resolveRenamedParm(PRM_ParmList& obsoleteParms,
         const char* oldName, const char* newName);
 
-#if (UT_VERSION_INT >= 0x0d000000) // 13.0.0 or later
     /// @brief Steal the geometry on the specified input if possible, instead of copying the data.
     ///
     /// @details In certain cases where a node's input geometry isn't being shared with
@@ -135,15 +134,15 @@ protected:
     /// @param gdh      handle to manage input locking
     /// @param clean    (forwarded to duplicateSource())
     ///
-    /// @note From Houdini 13.0 on, this method will insert the existing data into the detail
-    /// and update the detail handle in the SOP.
+    /// @note Prior to Houdini 13.0, this method peforms a duplicateSource() and unlocks the
+    /// inputs to the SOP. From Houdini 13.0 on, this method will insert the existing data
+    /// into the detail and update the detail handle in the SOP.
     ///
     /// @warning No attempt to call duplicateSource() or inputGeo() should be made after
     /// calling this method, as there will be no data on the input stream if isSourceStealable()
     /// returns @c true.
     OP_ERROR duplicateSourceStealable(const unsigned index,
         OP_Context& context, GU_Detail **pgdp, GU_DetailHandle& gdh, bool clean = true);
-#endif
 
     /// @brief Steal the geometry on the specified input if possible, instead of copying the data.
     ///
@@ -156,10 +155,13 @@ protected:
     /// this method falls back to copying the shared pointer, effectively performing
     /// a duplicateSource().
     ///
+    /// @note Prior to Houdini 13.0, this method peforms a duplicateSource() and unlocks the
+    /// inputs to the SOP. From Houdini 13.0 on, this method will insert the existing data
+    /// into the detail and update the detail handle in the SOP.
+    ///
     /// @param index    the index of the input from which to perform this operation
     /// @param context  the current SOP context is used for cook time for network traversal
-    /// @param clean    (forwarded to duplicateSource())
-    OP_ERROR duplicateSourceStealable(const unsigned index, OP_Context& context, bool clean = true);
+    OP_ERROR duplicateSourceStealable(const unsigned index, OP_Context& context);
 
 private:
 #if (UT_VERSION_INT >= 0x0d000000) // 13.0.0 or later

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Convert.cc
@@ -1335,7 +1335,10 @@ SOP_OpenVDB_Convert::cookMySop(OP_Context& context)
     try {
         hutil::ScopedInputLock lock(*this, context);
 
-        duplicateSourceStealable(0, context);
+        // We are intentionally not performing a duplicateSourceStealable() here due to
+        // specific implementation in this SOP which causes undesirable behavior when
+        // attempting to "steal" the geometry
+        duplicateSource(0, context);
 
         const fpreal t = context.getTime();
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Filter.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Filter.cc
@@ -506,7 +506,9 @@ SOP_OpenVDB_Filter::cookMySop(OP_Context& context)
 #else
         if (lock.lock(*startNode, context) >= UT_ERROR_ABORT) return error();
 #endif
-        if (startNode->duplicateSourceStealable(0, context) >= UT_ERROR_ABORT) return error();
+
+        // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
+        if (startNode->duplicateSourceStealable(0, context, &gdp, myGdpHandle, /*clean = */ true) >= UT_ERROR_ABORT) return error();
 
         // Get the group of grids to process.
         UT_String groupStr;


### PR DESCRIPTION
Updates to duplicateSourceStealable workflow in Filter, Filter Level Set and Convert SOPs to resolve issues.

 - all duplicateSourceStealable signatures now accessible in all compiled versions of houdini
 - Filter SOPs provide the current gdp to the duplicateSourceStealable call initiated on the "startNode"
 - Convert SOP unable to use duplicateSourceStealable, replaced with duplicateSource