### PR TITLE
Minor change to Ray SOP

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Ray.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Ray.cc
@@ -505,7 +505,7 @@ SOP_OpenVDB_Ray::cookMySop(OP_Context& context)
 
             GA_RWAttributeRef aRef = gdp->findPointAttribute("dist");
             if (!aRef.isValid()) {
-                aRef = gdp->addIntTuple(GA_ATTRIB_POINT, "dist", 1, GA_Defaults(0));
+                aRef = gdp->addFloatTuple(GA_ATTRIB_POINT, "dist", 1, GA_Defaults(0.0));
             }
 #if (UT_VERSION_INT >= 0x0d0000c0)  // 13.0.192 or later
             gdp->setAttributeFromArray(aRef.getAttribute(), gdp->getPointRange(), distances);


### PR DESCRIPTION
Distance point attribute created as a float, rather than an int, if it doesn't exist.