### PR TITLE
Error in documentation (example code) at line 1029

### DIFF
--- a/openvdb/doc/examplecode.txt
+++ b/openvdb/doc/examplecode.txt
@@ -1026,7 +1026,7 @@ gridA = copyOfGridA->deepCopy();
 gridB = copyOfGridB->deepCopy();
 
 // Compute the difference (A / B) of the two level sets.
-openvdb::tools::csgDifference(gridA, gridB);
+openvdb::tools::csgDifference(*gridA, *gridB);
 @endcode
 
 


### PR DESCRIPTION
Error in one example of `Composite.h` operations (`cgsDifference(gridA,gridB)` instead of `cgsDifference(*gridA,*gridB)`)