### PR TITLE
Fix for rasterizing vector point attributes

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Rasterize_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Rasterize_Points.cc
@@ -2912,7 +2912,7 @@ getAttributeNames(
 
         const std::string& name = *it;
 
-        GA_ROAttributeRef attr = geo.findFloatTuple(GA_ATTRIB_POINT, name.c_str(), 1);
+        GA_ROAttributeRef attr = geo.findFloatTuple(GA_ATTRIB_POINT, name.c_str(), 1, 1);
 
         if (attr.isValid()) {
 


### PR DESCRIPTION
findFloatTuple(...) returns a valid handle to the first element of a vector attribute if there is no max_size specified (last argument). Previously vector attributes were being treated as floats.
