### PR TITLE
BUG: fix python3/2 numpy import_array macro build issue

### DIFF
--- a/openvdb/python/pyOpenVDBModule.cc
+++ b/openvdb/python/pyOpenVDBModule.cc
@@ -592,7 +592,11 @@ BOOST_PYTHON_MODULE(PY_OPENVDB_MODULE_NAME)
 
 #ifdef PY_OPENVDB_USE_NUMPY
     // Initialize NumPy.
+#if PY_MAJOR_VERSION >= 3
+    if (_import_array()) { };
+#else
     import_array();
+#endif
 #endif
 
     using namespace openvdb::OPENVDB_VERSION_NAME;


### PR DESCRIPTION
This fixes the issue faced in issue #68.

There might be a cleaner fix, but this does work.

Tested with Python v2.7, 3.4, and 3.5.
