### PR TITLE
Fix a crash in OpenVDB Combine SOP when using an unrecognised grid type

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Combine.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Combine.cc
@@ -1171,8 +1171,11 @@ SOP_OpenVDB_Combine::combineGrids(Operation op,
     compOp.bGridName = bGridName;
     compOp.interrupt = hvdb::Interrupter();
 
-    int success = UTvdbProcessTypedGridTopology(
-        UTvdbGetGridType(needA ? *aGrid : *bGrid), aGrid, compOp);
+    int success = 0;
+    UT_VDBType vdbType(UTvdbGetGridType(needA ? *aGrid : *bGrid));
+    if (vdbType != UT_VDB_INVALID) {
+        success = UTvdbProcessTypedGridTopology(vdbType, aGrid, compOp);
+    }
     if (!success || !compOp.outGrid) {
         std::ostringstream ostr;
         if (aGrid->type() == bGrid->type()) {


### PR DESCRIPTION
This is only when using the OpenVDB Combine SOP for "Copy A" and "Invert A" modes with both inputs connected. This bug appears with any non-HDK supported grid types (such as mask grids, point index grids or point data grids).