### PR TITLE
Minor update to makeSphereCode in documentation

### DIFF
--- a/openvdb/doc/examplecode.txt
+++ b/openvdb/doc/examplecode.txt
@@ -290,7 +290,7 @@ makeSphere(GridType& grid, float radius, const openvdb::Vec3f& c)
 
     // Propagate the outside/inside sign information from the narrow band
     // throughout the grid.
-    grid.signedFloodFill();
+    openvdb::tools::signedFloodFill(grid.tree());
 }
 @endcode
 


### PR DESCRIPTION
Example code was calling `Tree::signedFloodFill()`, this was replaced by `tools::signedFloodFill()` as of version 3.0.0