### PR TITLE
Correctly error when inserting a duplicate attribute with mis-matching type

### DIFF
--- a/openvdb/points/AttributeSet.cc
+++ b/openvdb/points/AttributeSet.cc
@@ -797,7 +797,8 @@ AttributeSet::Descriptor::insert(const std::string& name, const NamePair& typeNa
     size_t pos = INVALID_POS;
     auto it = mNameMap.find(name);
     if (it != mNameMap.end()) {
-        if (it->first != typeName.first) {
+        assert(it->second < mTypes.size());
+        if (mTypes[it->second] != typeName) {
             OPENVDB_THROW(KeyError, "Cannot insert into a Descriptor with a duplicate name, but different type.")
         }
         pos = it->second;

--- a/openvdb/unittest/TestAttributeSet.cc
+++ b/openvdb/unittest/TestAttributeSet.cc
@@ -631,6 +631,12 @@ TestAttributeSet::testAttributeSet()
         Descriptor::Ptr descrB =
             attrSetB.descriptor().duplicateAppend("test", AttributeS::attributeType());
 
+        // should throw if we attempt to add the same attribute name but a different type
+        CPPUNIT_ASSERT_THROW(descrB->insert("test", AttributeI::attributeType()), openvdb::KeyError);
+
+        // shouldn't throw if we attempt to add the same attribute name and type
+        CPPUNIT_ASSERT_NO_THROW(descrB->insert("test", AttributeS::attributeType()));
+
         openvdb::TypedMetadata<AttributeS::ValueType> defaultValueTest(5);
 
         // add a default value of the wrong type


### PR DESCRIPTION
This no longer silently allows inserting new attributes with identical names but mis-matching types to an already existing attribute into a Descriptor