### PR TITLE
Adjust Points Convert SOP defaults and add 16-bit truncate compression

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
@@ -912,7 +912,7 @@ newSopOperator(OP_OperatorTable* table)
             .setChoiceListItems(PRM_CHOICELIST_SINGLE, items));
     }
 
-    parms.add(hutil::ParmFactory(PRM_HEADING, "transferHeading", "Attribute transfer"));
+    parms.add(hutil::ParmFactory(PRM_HEADING, "transferHeading", "Attribute Transfer"));
 
      // Mode. Either convert all or convert specifc attributes
 
@@ -971,11 +971,12 @@ newSopOperator(OP_OperatorTable* table)
         const char* items[] = {
             "none", "None",
             UnitVecCodec::name(), "Unit Vector",
+            "truncate", "16-bit Truncate",
             nullptr
     };
 
     parms.add(hutil::ParmFactory(PRM_ORD, "normalcompression", "Normal Compression")
-        .setDefault(PRMoneDefaults)
+        .setDefault(PRMzeroDefaults)
         .setHelpText("All normal attributes will use this compression codec.")
         .setChoiceListItems(PRM_CHOICELIST_SINGLE, items));
     }
@@ -985,11 +986,12 @@ newSopOperator(OP_OperatorTable* table)
             "none", "None",
             FixedPointCodec<false, UnitRange>::name(), "16-bit Unit",
             FixedPointCodec<true, UnitRange>::name(), "8-bit Unit",
+            "truncate", "16-bit Truncate",
             nullptr
     };
 
     parms.add(hutil::ParmFactory(PRM_ORD, "colorcompression", "Color Compression")
-        .setDefault(PRMtwoDefaults)
+        .setDefault(PRMzeroDefaults)
         .setHelpText("All color attributes will use this compression codec.")
         .setChoiceListItems(PRM_CHOICELIST_SINGLE, items));
     }
@@ -1378,13 +1380,16 @@ SOP_OpenVDB_Points_Convert::cookMySop(OP_Context& context)
 
                     int valueCompression = NONE;
 
-                    if (isNormal && normalCompression == 1) {
-                        valueCompression = UNIT_VECTOR;
-                    } else if (isColor && colorCompression == 1) {
-                        valueCompression = UNIT_FIXED_POINT_16;
-                    } else if (isColor && colorCompression == 2) {
-                        valueCompression = UNIT_FIXED_POINT_8;
+                    if (isNormal) {
+                        if (normalCompression == 1)             valueCompression = UNIT_VECTOR;
+                        else if (normalCompression == 2)        valueCompression = TRUNCATE;
                     }
+                    else if (isColor) {
+                        if (colorCompression == 1)              valueCompression = UNIT_FIXED_POINT_16;
+                        else if (colorCompression == 2)         valueCompression = UNIT_FIXED_POINT_8;
+                        else if (colorCompression == 3)         valueCompression = TRUNCATE;
+                    }
+
                     // when converting all attributes apply no compression
                     attributes[attributeName] = std::pair<int, bool>(valueCompression, false);
                 }


### PR DESCRIPTION
* Change Points Convert SOP default values to not enable normal and color compression by default (this is safer because the range is not guaranteed to be between 0->1)
* Add 16-bit truncate compression as an option to the Points Convert SOP