### PR TITLE
Introduce sequential pre-fetching from disk for faster performance

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
@@ -1129,6 +1129,17 @@ SOP_OpenVDB_Points_Convert::cookMySop(OP_Context& context)
 
                 const PointDataGrid& grid = static_cast<const PointDataGrid&>(baseGrid);
 
+                // if all point data is being converted, sequentially pre-fetch any out-of-core
+                // data for faster performance when using delayed-loading
+
+                const bool allData =    emptyNameVector.empty() &&
+                                        includeGroups.empty() &&
+                                        excludeGroups.empty();
+
+                if (allData) {
+                    prefetch(grid.tree());
+                }
+
                 // perform conversion
 
                 hvdb::convertPointDataGridToHoudini(


### PR DESCRIPTION
When voxel and point attribute data is out-of-core and it is known that all the data will be read from disk, it is faster to sequentially pre-fetch the data using contiguous I/O rather than rely on on-demand loading in a multi-threaded context. Pre-fetching has minimal overhead if the data is already in-core.

Pre-fetching is exposed in the API and used in the Points Convert SOP.