### PR TITLE
Add Point Data Grid support to Clip SOP, Visualize SOP, Topology to Levelset SOP

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Topology_To_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Topology_To_Level_Set.cc
@@ -40,6 +40,7 @@
 
 #include <openvdb/tools/TopologyToLevelSet.h>
 #include <openvdb/tools/LevelSetUtil.h>
+#include <openvdb/points/PointDataGrid.h>
 
 #include <UT/UT_Interrupt.h>
 #include <GA/GA_Handle.h>
@@ -288,7 +289,10 @@ SOP_OpenVDB_Topology_To_Level_Set::cookMySop(OP_Context& context)
                     openvdb::tools::PointIndexGrid::ConstPtr grid =
                         openvdb::gridConstPtrCast<openvdb::tools::PointIndexGrid>(vdb->getGridPtr());
                     converter(*grid);
-
+                } else if (vdb->getGrid().type() == openvdb::points::PointDataGrid::gridType()) { // point data grid
+                    openvdb::points::PointDataGrid::ConstPtr grid =
+                        openvdb::gridConstPtrCast<openvdb::points::PointDataGrid>(vdb->getGridPtr());
+                    converter(*grid);
                 } else if (vdb->getGrid().type() == openvdb::MaskGrid::gridType()) { // mask grid
                     openvdb::MaskGrid::ConstPtr grid =
                         openvdb::gridConstPtrCast<openvdb::MaskGrid>(vdb->getGridPtr());

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Visualize.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Visualize.cc
@@ -40,6 +40,7 @@
 #include <openvdb_houdini/Utils.h>
 #include <openvdb_houdini/SOP_NodeVDB.h>
 #include <openvdb/tools/PointIndexGrid.h>
+#include <openvdb/points/PointDataGrid.h>
 
 #ifdef DWA_OPENVDB
 #include <openvdb_houdini/DW_VDBUtils.h>
@@ -64,6 +65,8 @@
 namespace boost {
 template<> struct is_integral<openvdb::PointIndex32>: public boost::true_type {};
 template<> struct is_integral<openvdb::PointIndex64>: public boost::true_type {};
+template<> struct is_integral<openvdb::PointDataIndex32>: public boost::true_type {};
+template<> struct is_integral<openvdb::PointDataIndex64>: public boost::true_type {};
 }
 
 namespace hvdb = openvdb_houdini;
@@ -1145,6 +1148,11 @@ SOP_OpenVDB_Visualize::cookMySop(OP_Context& context)
                         if (vdb->getGrid().type() == openvdb::tools::PointIndexGrid::gridType()) {
                             openvdb::tools::PointIndexGrid::ConstPtr grid =
                                  openvdb::gridConstPtrCast<openvdb::tools::PointIndexGrid>(
+                                     vdb->getGridPtr());
+                            draw(*grid);
+                        } else if (vdb->getGrid().type() == openvdb::points::PointDataGrid::gridType()) {
+                            openvdb::points::PointDataGrid::ConstPtr grid =
+                                 openvdb::gridConstPtrCast<openvdb::points::PointDataGrid>(
                                      vdb->getGridPtr());
                             draw(*grid);
                         }


### PR DESCRIPTION
Adding trivial support for VDB Points to a few SOPs.
Clip SOP only supports inside bounding box clipping with VDB Points for now. Visualize and Topology to Levelset SOPs are fully supported with this change.