### PR TITLE
 v3.3.0 Windows fixes

### DIFF
--- a/openvdb/points/AttributeSet.cc
+++ b/openvdb/points/AttributeSet.cc
@@ -284,7 +284,8 @@ AttributeSet::groupIndex(const size_t offset) const
 
     // adjust relative offset to find offset into the array vector
 
-    return Util::GroupIndex(groups[offset / GROUP_BITS], offset % GROUP_BITS);
+    return Util::GroupIndex(groups[offset / GROUP_BITS],
+			    static_cast<uint8_t>(offset % GROUP_BITS));
 }
 
 

--- a/openvdb/tools/ParticleAtlas.h
+++ b/openvdb/tools/ParticleAtlas.h
@@ -465,7 +465,7 @@ private:
 template<typename ParticleArrayType, typename PointIndexLeafNodeType>
 struct RemapIndices {
 
-    RemapIndices(const ParticleArrayType& particles, std::vector<PointIndexLeafNodeType*> nodes)
+    RemapIndices(const ParticleArrayType& particles, std::vector<PointIndexLeafNodeType*>& nodes)
         : mParticles(&particles)
         , mNodes(nodes.empty() ? nullptr : &nodes.front())
     {

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -1131,9 +1131,8 @@ TestAttributeArray::testDelayedLoad()
 
         // write out attribute array to a temp file
         {
-            std::ofstream fileout;
             filename = tempDir + "/openvdb_delayed1";
-            fileout.open(filename.c_str());
+            std::ofstream fileout(filename.c_str(), std::ios_base::binary);
             io::setStreamMetadataPtr(fileout, streamMetadata);
             io::setDataCompression(fileout, io::COMPRESS_BLOSC);
 
@@ -1489,9 +1488,8 @@ TestAttributeArray::testDelayedLoad()
 
         // write out uniform attribute array to a temp file
         {
-            std::ofstream fileout;
             filename = tempDir + "/openvdb_delayed2";
-            fileout.open(filename.c_str());
+            std::ofstream fileout(filename.c_str(), std::ios_base::binary);
             io::setStreamMetadataPtr(fileout, streamMetadata);
             io::setDataCompression(fileout, io::COMPRESS_BLOSC);
 
@@ -1550,9 +1548,8 @@ TestAttributeArray::testDelayedLoad()
 
         // write out strided attribute array to a temp file
         {
-            std::ofstream fileout;
             filename = tempDir + "/openvdb_delayed3";
-            fileout.open(filename.c_str());
+            std::ofstream fileout(filename.c_str(), std::ios_base::binary);
             io::setStreamMetadataPtr(fileout, streamMetadata);
             io::setDataCompression(fileout, io::COMPRESS_BLOSC);
 
@@ -1599,9 +1596,8 @@ TestAttributeArray::testDelayedLoad()
 
         // write out compressed attribute array to a temp file
         {
-            std::ofstream fileout;
             filename = tempDir + "/openvdb_delayed4";
-            fileout.open(filename.c_str());
+            std::ofstream fileout(filename.c_str(), std::ios_base::binary);
             io::setStreamMetadataPtr(fileout, streamMetadata);
             io::setDataCompression(fileout, io::COMPRESS_BLOSC);
 

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -55,11 +55,10 @@
 
 #ifdef _MSC_VER
 #include <boost/interprocess/detail/os_file_functions.hpp> // open_existing_file(), close_file()
-extern "C" __declspec(dllimport) bool __stdcall GetFileTime(
-    void* fh, void* ctime, void* atime, void* mtime);
 // boost::interprocess::detail was renamed to boost::interprocess::ipcdetail in Boost 1.48.
 // Ensure that both namespaces exist.
 namespace boost { namespace interprocess { namespace detail {} namespace ipcdetail {} } }
+#include <windows.h>
 #else
 #include <sys/types.h> // for struct stat
 #include <sys/stat.h> // for stat()
@@ -1107,7 +1106,16 @@ TestAttributeArray::testDelayedLoad()
 
     std::string tempDir;
     if (const char* dir = std::getenv("TMPDIR")) tempDir = dir;
+#if _MSC_VER
+    if (tempDir.empty()) {
+        char tempDirBuffer[MAX_PATH+1];
+        int tempDirLen = GetTempPath(MAX_PATH+1, tempDirBuffer);
+        CPPUNIT_ASSERT(tempDirLen > 0 && tempDirLen <= MAX_PATH);
+        tempDir = tempDirBuffer;
+    }
+#else
     if (tempDir.empty()) tempDir = P_tmpdir;
+#endif
 
     { // IO
         const Index count = 50;

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -81,10 +81,24 @@ private:
         {
             mLastWriteTime = 0;
             const char* regionFilename = mMap.get_name();
+#ifdef _MSC_VER
+	    using namespace boost::interprocess::detail;
+	    using namespace boost::interprocess::ipcdetail;
+	    using openvdb::Index64;
+
+	    if (void* fh = open_existing_file(regionFilename, boost::interprocess::read_only)) {
+		FILETIME mtime;
+		if (GetFileTime(fh, nullptr, nullptr, &mtime)) {
+		    mLastWriteTime = (Index64(mtime.dwHighDateTime) << 32) | mtime.dwLowDateTime;
+		}
+		close_file(fh);
+	    }
+#else
             struct stat info;
             if (0 == ::stat(regionFilename, &info)) {
                 mLastWriteTime = openvdb::Index64(info.st_mtime);
             }
+#endif
         }
 
         using Notifier = std::function<void(std::string /*filename*/)>;

--- a/openvdb/unittest/TestCoord.cc
+++ b/openvdb/unittest/TestCoord.cc
@@ -334,9 +334,9 @@ TestCoord::testCoordBBox()
     {// bit-wise operations
         const openvdb::Coord min(-1,-2,3), max(2,3,5);
         const openvdb::CoordBBox b(min, max);
-        CPPUNIT_ASSERT_EQUAL(openvdb::CoordBBox(min>>1,max>>1), b>>1UL);
-        CPPUNIT_ASSERT_EQUAL(openvdb::CoordBBox(min>>3,max>>3), b>>3UL);
-        CPPUNIT_ASSERT_EQUAL(openvdb::CoordBBox(min<<1,max<<1), b<<1UL);
+        CPPUNIT_ASSERT_EQUAL(openvdb::CoordBBox(min>>1,max>>1), b>>size_t(1));
+        CPPUNIT_ASSERT_EQUAL(openvdb::CoordBBox(min>>3,max>>3), b>>size_t(3));
+        CPPUNIT_ASSERT_EQUAL(openvdb::CoordBBox(min<<1,max<<1), b<<size_t(1));
         CPPUNIT_ASSERT_EQUAL(openvdb::CoordBBox(min&1,max&1), b&1);
         CPPUNIT_ASSERT_EQUAL(openvdb::CoordBBox(min|1,max|1), b|1);
     }

--- a/openvdb/unittest/TestMultiResGrid.cc
+++ b/openvdb/unittest/TestMultiResGrid.cc
@@ -144,7 +144,7 @@ TestMultiResGrid::testManualTopology()
 
     CPPUNIT_ASSERT(mrg != nullptr);
     CPPUNIT_ASSERT_EQUAL(levels  , mrg->numLevels());
-    CPPUNIT_ASSERT_EQUAL(0UL,      mrg->finestLevel());
+    CPPUNIT_ASSERT_EQUAL(size_t(0), mrg->finestLevel());
     CPPUNIT_ASSERT_EQUAL(levels-1, mrg->coarsestLevel());
 
     // Define grid domain so they exactly overlap!
@@ -197,19 +197,19 @@ TestMultiResGrid::testManualTopology()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, mrg->prolongateVoxel(ijk, 0), /*tolerance=*/ 0.0);
 
     // First check the coarsest level (3)
-    for (CoordBBox::Iterator<true> iter(bbox>>3UL); iter; ++iter) {
+    for (CoordBBox::Iterator<true> iter(bbox>>size_t(3)); iter; ++iter) {
         CPPUNIT_ASSERT_DOUBLES_EQUAL(3.0, mrg->tree(3).getValue(*iter), /*tolerance=*/0.0);
     }
 
     // Prolongate from level 3 -> level 2 and check values
     mrg->prolongateActiveVoxels(2);
-    for (CoordBBox::Iterator<true> iter(bbox>>2UL); iter; ++iter) {
+    for (CoordBBox::Iterator<true> iter(bbox>>size_t(2)); iter; ++iter) {
         CPPUNIT_ASSERT_DOUBLES_EQUAL(3.0, mrg->tree(2).getValue(*iter), /*tolerance=*/0.0);
     }
 
     // Prolongate from level 2 -> level 1 and check values
     mrg->prolongateActiveVoxels(1);
-    for (CoordBBox::Iterator<true> iter(bbox>>1UL); iter; ++iter) {
+    for (CoordBBox::Iterator<true> iter(bbox>>size_t(1)); iter; ++iter) {
         CPPUNIT_ASSERT_DOUBLES_EQUAL(3.0, mrg->tree(1).getValue(*iter), /*tolerance=*/0.0);
     }
 
@@ -267,7 +267,7 @@ TestMultiResGrid::testIO()
     //mrg.print( std::cout, 3 );
 
     CPPUNIT_ASSERT_EQUAL(levels  , mrg.numLevels());
-    CPPUNIT_ASSERT_EQUAL(0UL     , mrg.finestLevel());
+    CPPUNIT_ASSERT_EQUAL(size_t(0), mrg.finestLevel());
     CPPUNIT_ASSERT_EQUAL(levels-1, mrg.coarsestLevel());
 
     // Check inside and outside values

--- a/openvdb/unittest/TestPointConversion.cc
+++ b/openvdb/unittest/TestPointConversion.cc
@@ -36,6 +36,10 @@
 #include <openvdb/points/PointCount.h>
 #include <openvdb/points/PointGroup.h>
 
+#ifdef _MSC_VER
+#include <windows.h>
+#endif
+
 using namespace openvdb;
 using namespace openvdb::points;
 
@@ -240,7 +244,7 @@ TestPointConversion::testPointConversion()
 
     // generate points
 
-    const unsigned long count(1000000);
+    const size_t count(1000000);
 
     AttributeWrapper<Vec3f> position(1);
     AttributeWrapper<int> xyz(1);
@@ -305,8 +309,16 @@ TestPointConversion::testPointConversion()
 
     std::string tempDir;
     if (const char* dir = std::getenv("TMPDIR")) tempDir = dir;
+#if _MSC_VER
+    if (tempDir.empty()) {
+        char tempDirBuffer[MAX_PATH+1];
+        int tempDirLen = GetTempPath(MAX_PATH+1, tempDirBuffer);
+        CPPUNIT_ASSERT(tempDirLen > 0 && tempDirLen <= MAX_PATH);
+        tempDir = tempDirBuffer;
+    }
+#else
     if (tempDir.empty()) tempDir = P_tmpdir;
-
+#endif
 
     std::string filename = tempDir + "/openvdb_test_point_conversion";
 
@@ -407,7 +419,7 @@ TestPointConversion::testPointConversion()
 
     // convert based on even group
 
-    const unsigned long halfCount = count / 2;
+    const size_t halfCount = count / 2;
 
     outputPosition.resize(startOffset + halfCount);
     outputId.resize(startOffset + halfCount);
@@ -480,7 +492,7 @@ TestPointConversion::testStride()
 
     // generate points
 
-    const unsigned long count(40000);
+    const size_t count(40000);
 
     AttributeWrapper<Vec3f> position(1);
     AttributeWrapper<int> xyz(3);
@@ -904,7 +916,7 @@ TestPointConversion::testComputeVoxelSize()
     // Generate a sphere
     // NOTE: The sphere does NOT provide uniform distribution
 
-    const unsigned long count(40000);
+    const size_t count(40000);
 
     position.resize(0);
 

--- a/openvdb/unittest/TestPointCount.cc
+++ b/openvdb/unittest/TestPointCount.cc
@@ -37,6 +37,10 @@
 #include <openvdb/points/PointCount.h>
 #include <openvdb/points/PointConversion.h>
 
+#if _MSC_VER
+#include <windows.h>
+#endif
+
 using namespace openvdb;
 using namespace openvdb::points;
 
@@ -222,7 +226,16 @@ TestPointCount::testGroup()
 
     std::string tempDir;
     if (const char* dir = std::getenv("TMPDIR")) tempDir = dir;
+#if _MSC_VER
+    if (tempDir.empty()) {
+        char tempDirBuffer[MAX_PATH+1];
+        int tempDirLen = GetTempPath(MAX_PATH+1, tempDirBuffer);
+        CPPUNIT_ASSERT(tempDirLen > 0 && tempDirLen <= MAX_PATH);
+        tempDir = tempDirBuffer;
+    }
+#else
     if (tempDir.empty()) tempDir = P_tmpdir;
+#endif
 
     std::string filename;
 
@@ -535,7 +548,16 @@ TestPointCount::testOffsets()
 
     std::string tempDir;
     if (const char* dir = std::getenv("TMPDIR")) tempDir = dir;
+#if _MSC_VER
+    if (tempDir.empty()) {
+        char tempDirBuffer[MAX_PATH+1];
+        int tempDirLen = GetTempPath(MAX_PATH+1, tempDirBuffer);
+        CPPUNIT_ASSERT(tempDirLen > 0 && tempDirLen <= MAX_PATH);
+        tempDir = tempDirBuffer;
+    }
+#else
     if (tempDir.empty()) tempDir = P_tmpdir;
+#endif
 
     std::string filename;
 

--- a/openvdb/unittest/TestPointGroup.cc
+++ b/openvdb/unittest/TestPointGroup.cc
@@ -36,6 +36,10 @@
 #include <iostream>
 #include <sstream>
 
+#ifdef _MSC_VER
+#include <windows.h>
+#endif
+
 using namespace openvdb;
 using namespace openvdb::points;
 
@@ -439,8 +443,16 @@ TestPointGroup::testSet()
 
         std::string tempDir;
         if (const char* dir = std::getenv("TMPDIR")) tempDir = dir;
+#if _MSC_VER
+	if (tempDir.empty()) {
+	    char tempDirBuffer[MAX_PATH+1];
+	    int tempDirLen = GetTempPath(MAX_PATH+1, tempDirBuffer);
+	    CPPUNIT_ASSERT(tempDirLen > 0 && tempDirLen <= MAX_PATH);
+	    tempDir = tempDirBuffer;
+	}
+#else
         if (tempDir.empty()) tempDir = P_tmpdir;
-
+#endif
 
         std::string filename;
 

--- a/openvdb/unittest/TestStreamCompression.cc
+++ b/openvdb/unittest/TestStreamCompression.cc
@@ -464,8 +464,7 @@ TestStreamCompression::testPagedStreams()
         io::StreamMetadata::Ptr streamMetadata(new io::StreamMetadata);
 
         { // ascending values up to 10 million written in blocks of PageSize/3
-            std::ofstream fileout;
-            fileout.open(filename.c_str());
+            std::ofstream fileout(filename.c_str(), std::ios_base::binary);
 
             io::setStreamMetadataPtr(fileout, streamMetadata);
             io::setDataCompression(fileout, openvdb::io::COMPRESS_BLOSC);

--- a/openvdb/unittest/TestStreamCompression.cc
+++ b/openvdb/unittest/TestStreamCompression.cc
@@ -55,11 +55,10 @@
 
 #ifdef _MSC_VER
 #include <boost/interprocess/detail/os_file_functions.hpp> // open_existing_file(), close_file()
-extern "C" __declspec(dllimport) bool __stdcall GetFileTime(
-    void* fh, void* ctime, void* atime, void* mtime);
 // boost::interprocess::detail was renamed to boost::interprocess::ipcdetail in Boost 1.48.
 // Ensure that both namespaces exist.
 namespace boost { namespace interprocess { namespace detail {} namespace ipcdetail {} } }
+#include <windows.h>
 #else
 #include <sys/types.h> // for struct stat
 #include <sys/stat.h> // for stat()
@@ -449,7 +448,16 @@ TestStreamCompression::testPagedStreams()
 
     std::string tempDir;
     if (const char* dir = std::getenv("TMPDIR")) tempDir = dir;
+#if _MSC_VER
+    if (tempDir.empty()) {
+        char tempDirBuffer[MAX_PATH+1];
+        int tempDirLen = GetTempPath(MAX_PATH+1, tempDirBuffer);
+        CPPUNIT_ASSERT(tempDirLen > 0 && tempDirLen <= MAX_PATH);
+        tempDir = tempDirBuffer;
+    }
+#else
     if (tempDir.empty()) tempDir = P_tmpdir;
+#endif
 
     {
         std::string filename = tempDir + "/openvdb_page1";


### PR DESCRIPTION
- Please recall that on Windows 64-bit, sizeof(long) != sizeof(size_t) 
  (https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models)
- Remember: Long is WRONG!
- All input/output files *must* be opened in binary mode
