### PR TITLE
FindILMBase, FindOpenEXR: Move Namespace version regex inside IF stat…

### DIFF
--- a/cmake/FindILMBase.cmake
+++ b/cmake/FindILMBase.cmake
@@ -57,15 +57,15 @@ OPTION ( ILMBASE_NAMESPACE_VERSIONING "Namespace versioning of libraries" ON )
 
 IF ( ILMBASE_FOUND )
 
-  FILE ( STRINGS "${ILMBASE_LOCATION}/include/OpenEXR/IlmBaseConfig.h" _ilmbase_version_major_string REGEX "#define ILMBASE_VERSION_MAJOR ")
-  STRING ( REGEX REPLACE "#define ILMBASE_VERSION_MAJOR" "" _ilmbase_version_major_unstrip "${_ilmbase_version_major_string}")
-  STRING ( STRIP ${_ilmbase_version_major_unstrip} ILMBASE_VERSION_MAJOR )
-
-  FILE ( STRINGS "${ILMBASE_LOCATION}/include/OpenEXR/IlmBaseConfig.h" _ilmbase_version_minor_string REGEX "#define ILMBASE_VERSION_MINOR ")
-  STRING ( REGEX REPLACE "#define ILMBASE_VERSION_MINOR" "" _ilmbase_version_minor_unstrip "${_ilmbase_version_minor_string}")
-  STRING ( STRIP ${_ilmbase_version_minor_unstrip} ILMBASE_VERSION_MINOR )
-
   IF ( ILMBASE_NAMESPACE_VERSIONING )
+	FILE ( STRINGS "${ILMBASE_LOCATION}/include/OpenEXR/IlmBaseConfig.h" _ilmbase_version_major_string REGEX "#define ILMBASE_VERSION_MAJOR ")
+	STRING ( REGEX REPLACE "#define ILMBASE_VERSION_MAJOR" "" _ilmbase_version_major_unstrip "${_ilmbase_version_major_string}")
+	STRING ( STRIP ${_ilmbase_version_major_unstrip} ILMBASE_VERSION_MAJOR )
+
+	FILE ( STRINGS "${ILMBASE_LOCATION}/include/OpenEXR/IlmBaseConfig.h" _ilmbase_version_minor_string REGEX "#define ILMBASE_VERSION_MINOR ")
+	STRING ( REGEX REPLACE "#define ILMBASE_VERSION_MINOR" "" _ilmbase_version_minor_unstrip "${_ilmbase_version_minor_string}")
+	STRING ( STRIP ${_ilmbase_version_minor_unstrip} ILMBASE_VERSION_MINOR )
+
 	SET ( IEX_LIBRARY_NAME       Iex-${ILMBASE_VERSION_MAJOR}_${ILMBASE_VERSION_MINOR}       )
 	SET ( IEXMATH_LIBRARY_NAME   IexMath-${ILMBASE_VERSION_MAJOR}_${ILMBASE_VERSION_MINOR}   )
 	SET ( ILMTHREAD_LIBRARY_NAME IlmThread-${ILMBASE_VERSION_MAJOR}_${ILMBASE_VERSION_MINOR} )

--- a/cmake/FindOpenEXR.cmake
+++ b/cmake/FindOpenEXR.cmake
@@ -52,19 +52,21 @@ OPTION ( OPENEXR_NAMESPACE_VERSIONING "Namespace versioning of libraries" ON )
 
 IF ( OPENEXR_FOUND )
 
-  FILE ( STRINGS "${OPENEXR_LOCATION}/include/OpenEXR/OpenEXRConfig.h" _openexr_version_major_string REGEX "#define OPENEXR_VERSION_MAJOR ")
-  STRING ( REGEX REPLACE "#define OPENEXR_VERSION_MAJOR" "" _openexr_version_major_unstrip "${_openexr_version_major_string}")
-  STRING ( STRIP ${_openexr_version_major_unstrip} OPENEXR_VERSION_MAJOR )
-
-  FILE ( STRINGS "${OPENEXR_LOCATION}/include/OpenEXR/OpenEXRConfig.h" _openexr_version_minor_string REGEX "#define OPENEXR_VERSION_MINOR ")
-  STRING ( REGEX REPLACE "#define OPENEXR_VERSION_MINOR" "" _openexr_version_minor_unstrip "${_openexr_version_minor_string}")
-  STRING ( STRIP ${_openexr_version_minor_unstrip} OPENEXR_VERSION_MINOR )
-  
-  MESSAGE ( STATUS "Found OpenEXR v${OPENEXR_VERSION_MAJOR}.${OPENEXR_VERSION_MINOR} at ${OPENEXR_LOCATION}" )
-
   IF ( OPENEXR_NAMESPACE_VERSIONING )
+	FILE ( STRINGS "${OPENEXR_LOCATION}/include/OpenEXR/OpenEXRConfig.h" _openexr_version_major_string REGEX "#define OPENEXR_VERSION_MAJOR ")
+	STRING ( REGEX REPLACE "#define OPENEXR_VERSION_MAJOR" "" _openexr_version_major_unstrip "${_openexr_version_major_string}")
+	STRING ( STRIP ${_openexr_version_major_unstrip} OPENEXR_VERSION_MAJOR )
+
+	FILE ( STRINGS "${OPENEXR_LOCATION}/include/OpenEXR/OpenEXRConfig.h" _openexr_version_minor_string REGEX "#define OPENEXR_VERSION_MINOR ")
+	STRING ( REGEX REPLACE "#define OPENEXR_VERSION_MINOR" "" _openexr_version_minor_unstrip "${_openexr_version_minor_string}")
+	STRING ( STRIP ${_openexr_version_minor_unstrip} OPENEXR_VERSION_MINOR )
+  
+	MESSAGE ( STATUS "Found OpenEXR v${OPENEXR_VERSION_MAJOR}.${OPENEXR_VERSION_MINOR} at ${OPENEXR_LOCATION}" )
+
 	SET ( ILMIMF_LIBRARY_NAME IlmImf-${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR} )
   ELSE ( OPENEXR_NAMESPACE_VERSIONING )
+	MESSAGE ( STATUS "Found OpenEXR at ${OPENEXR_LOCATION}" )
+
 	SET ( ILMIMF_LIBRARY_NAME IlmImf )
   ENDIF ( OPENEXR_NAMESPACE_VERSIONING )
 	


### PR DESCRIPTION
…ement

If namespace versioning is off, then don't try to find the version
strings in IlmBaseConfig.h or OpenEXRConfig.h. On some distros,
those files are dummy files for multi-arch support, which just
contain includes to the real files and there is no version information
in these files. This will cause build failures as the variables
will be blank.

This is compile tested on Gentoo Linux.

Signed-off by: Jonathan Scruggs (j.scruggs@gmail.com)

This should also be backwards compatible with the 3.3.0 branch.

Example of what IlmBaseConfig.h contains on Gentoo Linux:
```
/* This file is auto-generated by multilib-build.eclass
 * as a multilib-friendly wrapper. For the original content,
 * please see the files that are #included below.
 */

#if defined(__x86_64__) /* amd64 */
#	if defined(__ILP32__) /* x32 ABI */
#		error "abi_x86_x32 not supported by the package."
#	else /* 64-bit ABI */
#		include <x86_64-pc-linux-gnu/OpenEXR/IlmBaseConfig.h>
#	endif
#elif defined(__i386__) /* plain x86 */
#	error "abi_x86_32 not supported by the package."
#elif defined(__mips__)
#   if(_MIPS_SIM == _ABIN32) /* n32 */
#       error "abi_mips_n32 not supported by the package."
#   elif(_MIPS_SIM == _ABI64) /* n64 */
#       error "abi_mips_n64 not supported by the package."
#   elif(_MIPS_SIM == _ABIO32) /* o32 */
#       error "abi_mips_o32 not supported by the package."
#   endif
#elif defined(__sparc__)
#	if defined(__arch64__)
#       error "abi_sparc_64 not supported by the package."
#	else
#       error "abi_sparc_32 not supported by the package."
#	endif
#elif defined(__s390__)
#	if defined(__s390x__)
#       error "abi_s390_64 not supported by the package."
#	else
#       error "abi_s390_32 not supported by the package."
#	endif
#elif defined(__powerpc__)
#	if defined(__powerpc64__)
#       error "abi_ppc_64 not supported by the package."
#	else
#       error "abi_ppc_32 not supported by the package."
#	endif
#elif defined(SWIG) /* https://sourceforge.net/p/swig/bugs/799/ */
#	include <x86_64-pc-linux-gnu/OpenEXR/IlmBaseConfig.h>
#else
#	error "No ABI matched, please report a bug to bugs.gentoo.org"
#endif
```

Programs link to this file and the C processor will include the appropriate file depending on the ARCH that it is being used to compile. We can have 32 and 64 bit versions of programs installed at the same time. My system is pure 64-bit, thus no 32-bit header is defined.

Cheers,
Jon