### PR TITLE
Introduce install_lib rule to Makefiles for library and maya

### DIFF
--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -44,6 +44,7 @@
 #   vdb_test            unit tests for the OpenVDB library
 #
 #   all                 [default target] all of the above
+#   install_lib         install the lib and the headers
 #   install             install all of the above except vdb_test
 #                       into subdirectories of DESTDIR
 #   depend              recompute source file header dependencies
@@ -865,20 +866,13 @@ test:
 	@echo "$@"': $$(CPPUNIT_INCL_DIR) is undefined'
 endif
 
-install: lib python vdb_print vdb_render vdb_view doc pydoc
+install_lib: lib
 	mkdir -p $(DESTDIR)/include/openvdb
 	@echo "Created $(DESTDIR)/include/openvdb"
 	pushd $(DESTDIR)/include/openvdb > /dev/null; \
 	    mkdir -p $(HEADER_SUBDIRS); popd > /dev/null
 	for f in $(INCLUDE_NAMES); \
 	    do cp -f $$f $(DESTDIR)/include/openvdb/$$f; done
-	@#
-	if [ -f $(LIBVIEWER) ]; \
-	then \
-	    mkdir -p $(DESTDIR)/include/openvdb_viewer; \
-	    echo "Created $(DESTDIR)/include/openvdb_viewer"; \
-	    cp -f $(LIBVIEWER_PUBLIC_INCLUDE_NAMES) $(DESTDIR)/include/openvdb_viewer/; \
-	fi
 	@echo "Copied header files to $(DESTDIR)/include"
 	@#
 	mkdir -p $(DESTDIR)/lib
@@ -891,6 +885,15 @@ install: lib python vdb_print vdb_render vdb_view doc pydoc
 	    fi; \
 	    popd > /dev/null
 	@echo "Copied libopenvdb to $(DESTDIR)/lib/"
+
+install: install_lib python vdb_print vdb_render vdb_view doc pydoc
+	if [ -f $(LIBVIEWER) ]; \
+	then \
+	    mkdir -p $(DESTDIR)/include/openvdb_viewer; \
+	    echo "Created $(DESTDIR)/include/openvdb_viewer"; \
+	    cp -f $(LIBVIEWER_PUBLIC_INCLUDE_NAMES) $(DESTDIR)/include/openvdb_viewer/; \
+	fi
+	@echo "Copied vdb_view header files to $(DESTDIR)/include"
 	@#
 	if [ -f $(LIBVIEWER) ]; \
 	then \

--- a/openvdb_maya/Makefile
+++ b/openvdb_maya/Makefile
@@ -29,7 +29,8 @@
 
 # Targets:
 #   all                 [default target] all Maya plugins
-#   install             install plugins, scripts, etc. into MAYA_DESTDIR
+#   install_lib         install plugins into MAYA_DESTDIR
+#   install             install all plugins, scripts, etc. into MAYA_DESTDIR
 #   clean               delete generated files from the local directory
 #   depend              recompute source file header dependencies
 #
@@ -273,11 +274,13 @@ $(MAYA_SO_NAME): $(MAYA_OBJ_NAMES)
 	@echo "Building $@ because of $(call list_deps)"
 	$(CXX) $(CXXFLAGS) -fPIC -Wl,-Bsymbolic -shared -o $@ $^ $(LIBS)
 
-install: $(MAYA_SO_NAME)
+install_lib: $(MAYA_SO_NAME)
 	mkdir -p $(MAYA_DESTDIR)/plugins
 	@echo "Created $(MAYA_DESTDIR)/plugins"
 	cp -f $(MAYA_SO_NAME) $(MAYA_DESTDIR)/plugins/
 	@echo "Copied $(MAYA_SO_NAME) to $(MAYA_DESTDIR)/plugins/"
+
+install: install_lib
 	mkdir -p $(MAYA_DESTDIR)/scripts
 	@echo "Created $(MAYA_DESTDIR)/scripts"
 	cp -f $(MAYA_SCRIPTS) $(MAYA_DESTDIR)/scripts/


### PR DESCRIPTION
In the same style as the introduction of the recent install_lib rule for the Houdini makefile, this adds matching rules for the library and the Maya makefile to build and install the compiled libraries only. This is particularly useful for the library makefile as it avoids building the additional binaries (print, render, viewer, etc).