### PR TITLE
Fix initialization bug with point data grid types

### DIFF
--- a/openvdb/openvdb.cc
+++ b/openvdb/openvdb.cc
@@ -106,8 +106,13 @@ initialize()
     Metadata::registerType(typeNameAsString<PointIndex64>(), Int64Metadata::createMetadata);
     tools::PointIndexGrid::registerGrid();
 
-    // Register types associated with point data grids.
 //#ifdef OPENVDB_ENABLE_POINTS
+    // Register types associated with point data grids.
+    Metadata::registerType(typeNameAsString<PointDataIndex32>(), Int32Metadata::createMetadata);
+    Metadata::registerType(typeNameAsString<PointDataIndex64>(), Int64Metadata::createMetadata);
+    points::PointDataGrid::registerGrid();
+
+    // Register point attribute types.
     points::initialize();
 //#endif
 

--- a/openvdb/points/PointDataGrid.h
+++ b/openvdb/points/PointDataGrid.h
@@ -1613,10 +1613,10 @@ prefetch(PointDataTreeT& tree)
 
 
 /// @brief Global registration of point data-related types
-void initialize();
+OPENVDB_API void initialize();
 
 /// @brief Global deregistration of point data-related types
-void uninitialize();
+OPENVDB_API void uninitialize();
 
 } // namespace points
 

--- a/openvdb/points/points.cc
+++ b/openvdb/points/points.cc
@@ -75,11 +75,6 @@ initialize()
 
     // Register attribute arrays with unit vector compression
     TypedAttributeArray<math::Vec3<float>, UnitVecCodec>::registerType();
-
-    // Register types associated with point data grids.
-    Metadata::registerType(typeNameAsString<PointDataIndex32>(), Int32Metadata::createMetadata);
-    Metadata::registerType(typeNameAsString<PointDataIndex64>(), Int64Metadata::createMetadata);
-    PointDataGrid::registerGrid();
 }
 
 


### PR DESCRIPTION
Resolve initialization issues when calling openvdb::points::initialize()