### PR TITLE
Point Serialization Fixes

### DIFF
--- a/openvdb/Grid.h
+++ b/openvdb/Grid.h
@@ -1460,7 +1460,8 @@ Grid<TreeT>::readBuffers(std::istream& is)
         is.read(reinterpret_cast<char*>(&numPasses), sizeof(uint16_t));
         const io::StreamMetadata::Ptr meta = io::getStreamMetadataPtr(is);
         assert(bool(meta));
-        for (uint32_t pass = 0; pass < uint32_t(numPasses); ++pass) {
+        for (uint16_t passIndex = 0; passIndex < numPasses; ++passIndex) {
+            uint32_t pass = (uint32_t(numPasses) << 16) | uint32_t(passIndex);
             meta->setPass(pass);
             tree().readBuffers(is, saveFloatAsHalf());
         }
@@ -1483,7 +1484,8 @@ Grid<TreeT>::readBuffers(std::istream& is, const CoordBBox& bbox)
         is.read(reinterpret_cast<char*>(&numPasses), sizeof(uint16_t));
         const io::StreamMetadata::Ptr meta = io::getStreamMetadataPtr(is);
         assert(bool(meta));
-        for (uint32_t pass = 0; pass < uint32_t(numPasses); ++pass) {
+        for (uint16_t passIndex = 0; passIndex < numPasses; ++passIndex) {
+            uint32_t pass = (uint32_t(numPasses) << 16) | uint32_t(passIndex);
             meta->setPass(pass);
             tree().readBuffers(is, saveFloatAsHalf());
         }
@@ -1523,7 +1525,8 @@ Grid<TreeT>::writeBuffers(std::ostream& os) const
         meta->setCountingPasses(false);
 
         // Save out the data blocks of the grid.
-        for (uint32_t pass = 0; pass < uint32_t(numPasses); ++pass) {
+        for (uint16_t passIndex = 0; passIndex < numPasses; ++passIndex) {
+            uint32_t pass = (uint32_t(numPasses) << 16) | uint32_t(passIndex);
             meta->setPass(pass);
             tree().writeBuffers(os, saveFloatAsHalf());
         }

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -1427,6 +1427,16 @@ TypedAttributeArray<ValueType_, Codec_>::readMetadata(std::istream& is)
     is.read(reinterpret_cast<char*>(&size), sizeof(Index));
     mSize = size;
 
+    // warn if an unknown flag has been set
+    if (mFlags >= 0x20) {
+        OPENVDB_LOG_WARN("Unknown attribute flags for VDB file format.");
+    }
+    // error if an unknown serialization flag has been set,
+    // as this will adjust the layout of the data and corrupt the ability to read
+    if (mSerializationFlags >= 0x10) {
+        OPENVDB_THROW(IoError, "Unknown attribute serialization flags for VDB file format.");
+    }
+
     // read uniform and compressed state
 
     mIsUniform = mSerializationFlags & WRITEUNIFORM;

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -1569,13 +1569,16 @@ TypedAttributeArray<ValueType_, Codec_>::writeMetadata(std::ostream& os, bool ou
 {
     if (!outputTransient && this->isTransient())    return;
 
-    uint8_t flags(mFlags);
-    uint8_t serializationFlags(mSerializationFlags);
+    uint8_t flags(mFlags & uint8_t(~OUTOFCORE));
+    uint8_t serializationFlags(0);
     Index size(mSize);
     Index stride(mStrideOrTotalSize);
     bool strideOfOne(this->stride() == 1);
 
     bool bloscCompression = io::getDataCompression(os) & io::COMPRESS_BLOSC;
+
+    // any compressed data needs to be loaded if out-of-core
+    if (bloscCompression || this->isCompressed())    this->doLoad();
 
     size_t compressedBytes = 0;
 
@@ -1605,8 +1608,6 @@ TypedAttributeArray<ValueType_, Codec_>::writeMetadata(std::ostream& os, bool ou
     }
     else if (bloscCompression)
     {
-        this->doLoad();
-
         const char* charBuffer = reinterpret_cast<const char*>(mData.get());
         const size_t inBytes = this->arrayMemUsage();
         compressedBytes = compression::bloscCompressedSize(charBuffer, inBytes);

--- a/openvdb/unittest/TestFile.cc
+++ b/openvdb/unittest/TestFile.cc
@@ -1919,7 +1919,9 @@ struct MultiPassLeafNode: public openvdb::tree::LeafNode<T, Log2Dim>, openvdb::i
             OPENVDB_THROW(openvdb::IoError,
                 "Cannot write out a MultiBufferLeaf without StreamMetadata.");
         }
-        const uint32_t pass = meta->pass();
+
+        // clamp pass to 16-bit integer
+        const uint32_t pass(static_cast<uint16_t>(meta->pass()));
 
         // Read in the stored pass number.
         uint32_t readPass;
@@ -1943,7 +1945,9 @@ struct MultiPassLeafNode: public openvdb::tree::LeafNode<T, Log2Dim>, openvdb::i
             OPENVDB_THROW(openvdb::IoError,
                 "Cannot read in a MultiBufferLeaf without StreamMetadata.");
         }
-        const uint32_t pass = meta->pass();
+
+        // clamp pass to 16-bit integer
+        const uint32_t pass(static_cast<uint16_t>(meta->pass()));
 
         // Leaf traversal analysis deduces the number of passes to perform for this leaf
         // then updates the leaf traversal value to ensure all passes will be written.


### PR DESCRIPTION
Both of these changes do not change the file format or the ABI.

* Bug fix where writing out-of-core arrays could corrupt the metadata being written with an AttributeArray as the serialization flags are used to retain information about how the data is stored before being brought in-core. This issue can cause segmentation faults without this fix.
* Improvements to the multi-pass I/O in being able to correctly handle a variable number of passes per-leaf.