### PR TITLE
Point deletion

### DIFF
--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -348,6 +348,7 @@ INCLUDE_NAMES := \
     points/PointConversion.h \
     points/PointCount.h \
     points/PointDataGrid.h \
+    points/PointDelete.h \
     points/PointGroup.h \
     points/StreamCompression.h \
     tools/ChangeBackground.h \
@@ -510,6 +511,7 @@ UNITTEST_SRC_NAMES := \
     unittest/TestPointConversion.cc \
     unittest/TestPointCount.cc \
     unittest/TestPointDataLeaf.cc \
+    unittest/TestPointDelete.cc \
     unittest/TestPointGroup.cc \
     unittest/TestPointIndexGrid.cc \
     unittest/TestPointPartitioner.cc \

--- a/openvdb/points/AttributeSet.h
+++ b/openvdb/points/AttributeSet.h
@@ -386,12 +386,23 @@ public:
     void dropGroup(const Name& group);
     /// Clear all groups
     void clearGroups();
+    /// Rename a group
+    size_t renameGroup(const std::string& fromName, const std::string& toName);
+    /// Return a unique name for a group based on given name
+    const Name uniqueGroupName(const Name& name) const;
 
     /// Return a unique name for an attribute array based on given name
     const Name uniqueName(const Name& name) const;
 
     /// Return true if the name is valid
     static bool validName(const Name& name);
+
+    /// Extract each name from nameStr into includeNames, or into excludeNames if name prefixed with caret
+    /// @param includeAll denotes whether a "*" wildcard is present in the includeNames
+    static void parseNames( std::vector<std::string>& includeNames,
+                            std::vector<std::string>& excludeNames,
+                            bool& includeAll,
+                            const std::string& nameStr);
 
     /// Extract each name from nameStr into includeNames, or into excludeNames if name prefixed with caret
     static void parseNames( std::vector<std::string>& includeNames,

--- a/openvdb/points/PointDelete.h
+++ b/openvdb/points/PointDelete.h
@@ -1,0 +1,232 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+
+/// @author Nick Avramoussis, Francisco Gochez
+///
+/// @file PointDelete.h
+///
+/// @brief Methods for deleting points based on group membership
+///
+
+#ifndef OPENVDB_POINTS_POINT_DELETE_HAS_BEEN_INCLUDED
+#define OPENVDB_POINTS_POINT_DELETE_HAS_BEEN_INCLUDED
+
+#include "PointDataGrid.h"
+#include "PointGroup.h"
+#include "IndexIterator.h"
+#include "IndexFilter.h"
+
+#include <openvdb/tree/LeafManager.h>
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+
+/// @brief   Delete points that are members of specific groups
+///
+/// @details This method will delete points which are members of any of the supplied groups and
+///          drop the groups from the tree. Optionally an invert flag can be used to delete
+///          points that belong to none of the groups.
+///
+/// @param   pointTree    the point tree
+/// @param   groups       the groups from which to delete points
+/// @param   invert       if enabled, points not belonging to any of the groups will be deleted
+///
+/// @note    If the invert flag is true, none of the groups will be dropped after deleting points.
+
+template <typename PointDataTree>
+inline void deleteFromGroups(PointDataTree& pointTree, const std::vector<std::string>& groups,
+                             bool invert = false);
+
+/// @brief   Delete points that are members of a group
+///
+/// @details This method will delete points which are members of the supplied group and drop the
+///          group from the tree. Optionally an invert flag can be used to delete
+///          points that belong to none of the groups.
+///
+/// @param   pointTree    the point tree with the group to delete
+/// @param   groups       the name of the group to delete
+/// @param   invert       If this flag is set to true, points *not* in this group will be deleted
+///
+/// @note    If the invert flag is true, the group will not be dropped after deleting points.
+
+template <typename PointDataTree>
+inline void deleteFromGroup(PointDataTree& pointTree, const std::string& group,
+                            bool invert = false);
+
+
+////////////////////////////////////////
+
+
+namespace point_delete_internal {
+
+
+template <typename PointDataTreeT>
+struct DeleteGroupsOp
+{
+    using LeafManagerT = tree::LeafManager<PointDataTreeT>;
+    using LeafRangeT = typename LeafManagerT::LeafRange;
+    using LeafNodeT = typename PointDataTreeT::LeafNodeType;
+    using ValueType = typename LeafNodeT::ValueType;
+
+    DeleteGroupsOp(const std::vector<std::string>& groupNames, bool invert)
+        : mGroupNames(groupNames)
+        , mInvert(invert) { }
+
+    void operator()(const LeafRangeT& range) const
+    {
+        // based on the invert parameter reverse the include and exclude arguments
+
+        std::unique_ptr<MultiGroupFilter> filter;
+        if (mInvert) {
+            filter.reset(new MultiGroupFilter(mGroupNames, std::vector<std::string>()));
+        }
+        else {
+            filter.reset(new MultiGroupFilter(std::vector<std::string>(), mGroupNames));
+        }
+
+        for (auto leaf = range.begin(); leaf != range.end(); ++leaf)
+        {
+            // early-exit if the leaf has no points
+            const size_t size = iterCount(leaf->beginIndexAll());
+            if (size == 0)    continue;
+
+            const size_t newSize =
+                iterCount(leaf->template beginIndexAll<MultiGroupFilter>(*filter));
+
+            // if all points are being deleted, clear the leaf attributes
+            if (newSize == 0) {
+                leaf->clearAttributes();
+                continue;
+            }
+
+            const AttributeSet& existingAttributeSet = leaf->attributeSet();
+            AttributeSet* newAttributeSet = new AttributeSet(existingAttributeSet, newSize);
+            const size_t attributeSetSize = existingAttributeSet.size();
+
+            // cache the attribute arrays for efficiency
+
+            std::vector<AttributeArray*> newAttributeArrays;
+            std::vector<const AttributeArray*> existingAttributeArrays;
+
+            for (size_t i = 0; i < attributeSetSize; i++) {
+                newAttributeArrays.push_back(newAttributeSet->get(i));
+                existingAttributeArrays.push_back(existingAttributeSet.getConst(i));
+            }
+
+            size_t attributeIndex = 0;
+            std::vector<ValueType> endOffsets;
+
+            endOffsets.reserve(LeafNodeT::NUM_VALUES);
+
+            // now construct new attribute arrays which exclude data from deleted points
+
+            for (auto voxel = leaf->cbeginValueAll(); voxel; ++voxel) {
+                for (auto iter = leaf->beginIndexVoxel(voxel.getCoord(), *filter);
+                     iter; ++iter) {
+                    for (size_t i = 0; i < attributeSetSize; i++) {
+                        newAttributeArrays[i]->set(attributeIndex, *(existingAttributeArrays[i]),
+                            *iter);
+                    }
+                    ++attributeIndex;
+                }
+                endOffsets.push_back(ValueType(attributeIndex));
+            }
+
+            leaf->replaceAttributeSet(newAttributeSet);
+            leaf->setOffsets(endOffsets);
+        }
+    }
+
+private:
+    const std::vector<std::string>& mGroupNames;
+    bool mInvert;
+}; // struct DeleteGroupsOp
+
+} // namespace point_delete_internal
+
+
+////////////////////////////////////////
+
+
+template <typename PointDataTreeT>
+inline void deleteFromGroups(PointDataTreeT& pointTree, const std::vector<std::string>& groups,
+    bool invert)
+{
+    const typename PointDataTreeT::LeafCIter leafIter = pointTree.cbeginLeaf();
+
+    if (!leafIter)    return;
+
+    const openvdb::points::AttributeSet& attributeSet = leafIter->attributeSet();
+    const AttributeSet::Descriptor& descriptor = attributeSet.descriptor();
+    std::vector<std::string> availableGroups;
+
+    // determine which of the requested groups exist, and early exit
+    // if none are present in the tree
+
+    for (const auto& groupName : groups) {
+        if (descriptor.hasGroup(groupName)) {
+            availableGroups.push_back(groupName);
+        }
+    }
+
+    if (availableGroups.empty())    return;
+
+    tree::LeafManager<PointDataTreeT> leafManager(pointTree);
+    point_delete_internal::DeleteGroupsOp<PointDataTreeT> deleteOp(availableGroups, invert);
+    tbb::parallel_for(leafManager.leafRange(), deleteOp);
+
+    // drop the now-empty groups (unless invert = true)
+
+    if (!invert) {
+        dropGroups(pointTree, availableGroups);
+    }
+}
+
+template <typename PointDataTreeT>
+inline void deleteFromGroup(PointDataTreeT& pointTree, const std::string& group, bool invert)
+{
+    std::vector<std::string> groups(1, group);
+
+    deleteFromGroups(pointTree, groups, invert);
+}
+
+
+} // namespace points
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif // OPENVDB_POINTS_POINT_DELETE_HAS_BEEN_INCLUDED
+
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/unittest/TestAttributeSet.cc
+++ b/openvdb/unittest/TestAttributeSet.cc
@@ -295,7 +295,7 @@ TestAttributeSet::testAttributeSetDescriptor()
         Descriptor::Inserter names2;
         Descriptor::Ptr emptyDescr = Descriptor::create(AttributeVec3f::attributeType());
         const openvdb::Name uniqueNameEmpty = emptyDescr->uniqueName("test");
-        CPPUNIT_ASSERT_EQUAL(uniqueNameEmpty, openvdb::Name("test0"));
+        CPPUNIT_ASSERT_EQUAL(uniqueNameEmpty, openvdb::Name("test"));
 
         names2.add("test", AttributeS::attributeType());
         names2.add("test1", AttributeI::attributeType());
@@ -378,7 +378,9 @@ TestAttributeSet::testAttributeSetDescriptor()
     { // Test single token parse
         std::vector<std::string> includeNames;
         std::vector<std::string> excludeNames;
-        Descriptor::parseNames(includeNames, excludeNames, "group1");
+        bool includeAll = false;
+        Descriptor::parseNames(includeNames, excludeNames, includeAll, "group1");
+        CPPUNIT_ASSERT(!includeAll);
         CPPUNIT_ASSERT(testStringVector(includeNames, "group1"));
         CPPUNIT_ASSERT(testStringVector(excludeNames));
     }
@@ -441,7 +443,9 @@ TestAttributeSet::testAttributeSetDescriptor()
     { // Test parse (*) character
         std::vector<std::string> includeNames;
         std::vector<std::string> excludeNames;
-        Descriptor::parseNames(includeNames, excludeNames, "*");
+        bool includeAll = false;
+        Descriptor::parseNames(includeNames, excludeNames, includeAll, "*");
+        CPPUNIT_ASSERT(includeAll);
         CPPUNIT_ASSERT(testStringVector(includeNames));
         CPPUNIT_ASSERT(testStringVector(excludeNames));
     }
@@ -990,6 +994,39 @@ TestAttributeSet::testAttributeSetGroups()
 
         CPPUNIT_ASSERT_NO_THROW(attrSet.groupIndex(23));
         CPPUNIT_ASSERT_THROW(attrSet.groupIndex(24), LookupError);
+    }
+
+    { // group unique name
+        Descriptor::Ptr descr = Descriptor::create(AttributeVec3s::attributeType());
+        const openvdb::Name uniqueNameEmpty = descr->uniqueGroupName("test");
+        CPPUNIT_ASSERT_EQUAL(uniqueNameEmpty, openvdb::Name("test"));
+
+        descr->setGroup("test", 1);
+        descr->setGroup("test1", 2);
+
+        const openvdb::Name uniqueName1 = descr->uniqueGroupName("test");
+        CPPUNIT_ASSERT_EQUAL(uniqueName1, openvdb::Name("test0"));
+        descr->setGroup(uniqueName1, 3);
+
+        const openvdb::Name uniqueName2 = descr->uniqueGroupName("test");
+        CPPUNIT_ASSERT_EQUAL(uniqueName2, openvdb::Name("test2"));
+    }
+
+    { // group rename
+        Descriptor::Ptr descr = Descriptor::create(AttributeVec3s::attributeType());
+        descr->setGroup("test", 1);
+        descr->setGroup("test1", 2);
+
+        size_t pos = descr->renameGroup("test", "test1");
+        CPPUNIT_ASSERT(pos == AttributeSet::INVALID_POS);
+        CPPUNIT_ASSERT(descr->hasGroup("test"));
+        CPPUNIT_ASSERT(descr->hasGroup("test1"));
+
+        pos = descr->renameGroup("test", "test2");
+        CPPUNIT_ASSERT_EQUAL(pos, size_t(1));
+        CPPUNIT_ASSERT(!descr->hasGroup("test"));
+        CPPUNIT_ASSERT(descr->hasGroup("test1"));
+        CPPUNIT_ASSERT(descr->hasGroup("test2"));
     }
 }
 

--- a/openvdb/unittest/TestPointDelete.cc
+++ b/openvdb/unittest/TestPointDelete.cc
@@ -1,0 +1,231 @@
+/////////////////////////////////////////////////////////
+//
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <openvdb/points/PointGroup.h>
+#include <openvdb/points/PointCount.h>
+#include <openvdb/points/PointConversion.h>
+#include <openvdb/points/PointDelete.h>
+
+#include <iostream>
+#include <sstream>
+
+#ifdef _MSC_VER
+#include <windows.h>
+#endif
+
+using namespace openvdb::points;
+
+class TestPointDelete: public CppUnit::TestCase
+{
+public:
+    virtual void setUp() { openvdb::initialize(); }
+    virtual void tearDown() { openvdb::uninitialize(); }
+
+    CPPUNIT_TEST_SUITE(TestPointDelete);
+    CPPUNIT_TEST(testDeleteFromGroups);
+
+    CPPUNIT_TEST_SUITE_END();
+
+    void testDeleteFromGroups();
+}; // class TestPointDelete
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestPointDelete);
+
+////////////////////////////////////////
+
+void
+TestPointDelete::testDeleteFromGroups()
+{
+    using openvdb::math::Vec3s;
+    using openvdb::tools::PointIndexGrid;
+    using openvdb::Index64;
+
+    const float voxelSize(1.0);
+    openvdb::math::Transform::Ptr transform(openvdb::math::Transform::createLinearTransform(voxelSize));
+
+    std::vector<Vec3s> positions6Points =  {
+                                                {1, 1, 1},
+                                                {1, 2, 1},
+                                                {2, 1, 1},
+                                                {2, 2, 1},
+                                                {100, 100, 100},
+                                                {100, 101, 100}
+                                           };
+    const PointAttributeVector<Vec3s> pointList6Points(positions6Points);
+
+    {
+        // delete from a tree with 2 leaves, checking that group membership is updated as
+        // expected
+
+        PointIndexGrid::Ptr pointIndexGrid =
+            openvdb::tools::createPointIndexGrid<PointIndexGrid>(pointList6Points, *transform);
+
+        PointDataGrid::Ptr grid =
+                createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid, pointList6Points, *transform);
+        PointDataTree& tree = grid->tree();
+
+        // first test will delete 3 groups, with the third one empty.
+
+        appendGroup(tree, "test1");
+        appendGroup(tree, "test2");
+        appendGroup(tree, "test3");
+        appendGroup(tree, "test4");
+
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(6));
+
+        std::vector<short> membership1{1, 0, 0, 0, 0, 1};
+
+        setGroup(tree, pointIndexGrid->tree(), membership1, "test1");
+
+        std::vector<short> membership2{0, 0, 1, 1, 0, 1};
+
+        setGroup(tree, pointIndexGrid->tree(), membership2, "test2");
+
+        std::vector<std::string> groupsToDelete{"test1", "test2", "test3"};
+
+        deleteFromGroups(tree, groupsToDelete);
+
+        // 4 points should have been deleted, so only 2 remain
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(2));
+
+        // check that first three groups are deleted but the last is not
+
+        const PointDataTree::LeafCIter leafIterAfterDeletion = tree.cbeginLeaf();
+
+        AttributeSet attributeSetAfterDeletion = leafIterAfterDeletion->attributeSet();
+        AttributeSet::Descriptor& descriptor = attributeSetAfterDeletion.descriptor();
+
+        CPPUNIT_ASSERT(!descriptor.hasGroup("test1"));
+        CPPUNIT_ASSERT(!descriptor.hasGroup("test2"));
+        CPPUNIT_ASSERT(!descriptor.hasGroup("test3"));
+        CPPUNIT_ASSERT(descriptor.hasGroup("test4"));
+    }
+
+    {
+        // check deletion from a single leaf tree and that attribute values are preserved
+        // correctly after deletion
+
+        std::vector<Vec3s> positions4Points = {
+                                                {1, 1, 1},
+                                                {1, 2, 1},
+                                                {2, 1, 1},
+                                                {2, 2, 1},
+                                              };
+
+        const PointAttributeVector<Vec3s> pointList4Points(positions4Points);
+
+        PointIndexGrid::Ptr pointIndexGrid =
+            openvdb::tools::createPointIndexGrid<PointIndexGrid>(pointList4Points, *transform);
+
+        PointDataGrid::Ptr grid =
+                createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid,
+                                                              pointList4Points, *transform);
+        PointDataTree& tree = grid->tree();
+
+        appendGroup(tree, "test");
+        appendAttribute(tree, "testAttribute", TypedAttributeArray<int32_t>::attributeType());
+
+        CPPUNIT_ASSERT(tree.beginLeaf());
+
+        const PointDataTree::LeafIter leafIter = tree.beginLeaf();
+
+        AttributeWriteHandle<int>
+            testAttributeWriteHandle(leafIter->attributeArray("testAttribute"));
+
+        for(int i = 0; i < 4; i++) {
+            testAttributeWriteHandle.set(i,i+1);
+        }
+
+        std::vector<short> membership{0, 1, 1, 0};
+        setGroup(tree, pointIndexGrid->tree(), membership, "test");
+
+        deleteFromGroup(tree, "test");
+
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(2));
+
+        const PointDataTree::LeafCIter leafIterAfterDeletion = tree.cbeginLeaf();
+        const AttributeSet attributeSetAfterDeletion = leafIterAfterDeletion->attributeSet();
+        const AttributeSet::Descriptor& descriptor = attributeSetAfterDeletion.descriptor();
+
+        CPPUNIT_ASSERT(descriptor.find("testAttribute") != AttributeSet::INVALID_POS);
+
+        AttributeHandle<int> testAttributeHandle(*attributeSetAfterDeletion.get("testAttribute"));
+
+        CPPUNIT_ASSERT_EQUAL(1, testAttributeHandle.get(0));
+        CPPUNIT_ASSERT_EQUAL(4, testAttributeHandle.get(1));
+    }
+
+    {
+        // test the invert flag using data similar to that used in the first test
+
+        PointIndexGrid::Ptr pointIndexGrid =
+            openvdb::tools::createPointIndexGrid<PointIndexGrid>(pointList6Points, *transform);
+        PointDataGrid::Ptr grid =
+                createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid, pointList6Points,
+                                                              *transform);
+        PointDataTree& tree = grid->tree();
+
+        appendGroup(tree, "test1");
+        appendGroup(tree, "test2");
+        appendGroup(tree, "test3");
+        appendGroup(tree, "test4");
+
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(6));
+
+        std::vector<short> membership1{1, 0, 1, 1, 0, 1};
+
+        setGroup(tree, pointIndexGrid->tree(), membership1, "test1");
+
+        std::vector<short> membership2{0, 0, 1, 1, 0, 1};
+
+        setGroup(tree, pointIndexGrid->tree(), membership2, "test2");
+
+        std::vector<std::string> groupsToDelete{"test1", "test3"};
+
+        deleteFromGroups(tree, groupsToDelete, true);
+
+        const PointDataTree::LeafCIter leafIterAfterDeletion = tree.cbeginLeaf();
+        const AttributeSet attributeSetAfterDeletion = leafIterAfterDeletion->attributeSet();
+        const AttributeSet::Descriptor& descriptor = attributeSetAfterDeletion.descriptor();
+
+        // no groups should be dropped when invert = true
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(descriptor.groupMap().size()),
+                             static_cast<size_t>(4));
+
+        // 4 points should remain since test1 and test3 have 4 members between then
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(pointCount(tree)),
+                             static_cast<size_t>(4));
+    }
+}
+
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb_houdini/Makefile
+++ b/openvdb_houdini/Makefile
@@ -280,6 +280,7 @@ HOUDINI_SOP_SRC_NAMES := \
     houdini/SOP_OpenVDB_Occlusion_Mask.cc \
     houdini/SOP_OpenVDB_Platonic.cc \
     houdini/SOP_OpenVDB_Points_Convert.cc \
+    houdini/SOP_OpenVDB_Points_Delete.cc \
     houdini/SOP_OpenVDB_Points_Group.cc \
     houdini/SOP_OpenVDB_Prune.cc \
     houdini/SOP_OpenVDB_Rasterize_Points.cc \

--- a/openvdb_houdini/houdini/PointUtils.cc
+++ b/openvdb_houdini/houdini/PointUtils.cc
@@ -32,6 +32,7 @@
 /// @authors Dan Bailey, Nick Avramoussis, Richard Kwok
 
 #include "PointUtils.h"
+#include "Utils.h"
 #include <openvdb/openvdb.h>
 #include <openvdb/util/Formats.h>
 #include <openvdb/points/AttributeArrayString.h>
@@ -41,9 +42,14 @@
 #include <sstream>
 #include <string>
 
+#include <CH/CH_Manager.h>
+#include <PRM/PRM_SpareData.h>
+#include <SOP/SOP_Node.h>
+
+namespace openvdb_houdini {
 
 void
-openvdb_houdini::convertPointDataGridToHoudini(
+convertPointDataGridToHoudini(
     GU_Detail& detail,
     const openvdb::points::PointDataGrid& grid,
     const std::vector<std::string>& attributes,
@@ -51,7 +57,9 @@ openvdb_houdini::convertPointDataGridToHoudini(
     const std::vector<std::string>& excludeGroups,
     const bool inCoreOnly)
 {
-    using openvdb_houdini::HoudiniWriteAttribute;
+    using openvdb::math::Vec3;
+    using openvdb::math::Quat;
+    using openvdb::math::Mat4;
 
     const openvdb::points::PointDataTree& tree = grid.tree();
 
@@ -70,13 +78,15 @@ openvdb_houdini::convertPointDataGridToHoudini(
 
     // obtain cumulative point offsets and total points
     std::vector<openvdb::Index64> pointOffsets;
-    const openvdb::Index64 total = getPointOffsets(pointOffsets, tree, includeGroups, excludeGroups, inCoreOnly);
+    const openvdb::Index64 total = getPointOffsets(pointOffsets, tree, includeGroups, excludeGroups,
+        inCoreOnly);
 
     // a block's global offset is needed to transform its point offsets to global offsets
     const openvdb::Index64 startOffset = detail.appendPointBlock(total);
 
     HoudiniWriteAttribute<openvdb::Vec3f> positionAttribute(*detail.getP());
-    convertPointDataGridPosition(positionAttribute, grid, pointOffsets, startOffset, includeGroups, excludeGroups, inCoreOnly);
+    convertPointDataGridPosition(positionAttribute, grid, pointOffsets, startOffset, includeGroups,
+        excludeGroups, inCoreOnly);
 
     // add other point attributes to the hdk detail
     const openvdb::points::AttributeSet::Descriptor::NameToPosMap& nameToPosMap = descriptor.map();
@@ -88,7 +98,10 @@ openvdb_houdini::convertPointDataGridToHoudini(
         if (name == "P")    continue;
 
         // filter attributes
-        if (!sortedAttributes.empty() && !std::binary_search(sortedAttributes.begin(), sortedAttributes.end(), name))   continue;
+        if (!sortedAttributes.empty() &&
+            !std::binary_search(sortedAttributes.begin(), sortedAttributes.end(), name)) {
+            continue;
+        }
 
         // don't convert group attributes
         if (descriptor.hasGroup(name))  continue;
@@ -142,7 +155,8 @@ openvdb_houdini::convertPointDataGridToHoudini(
                 attributeRef->getOptions().setTypeInfo(GA_TYPE_TRANSFORM);
             }
 
-            // '|' and ':' characters are valid in OpenVDB Points names but will make Houdini Attribute names invalid
+            // '|' and ':' characters are valid in OpenVDB Points names but
+            // will make Houdini Attribute names invalid
             if (attributeRef.isInvalid()) {
                 OPENVDB_THROW(  openvdb::RuntimeError,
                                 "Unable to create Houdini Points Attribute with name '" + name +
@@ -152,59 +166,73 @@ openvdb_houdini::convertPointDataGridToHoudini(
 
         if (valueType == "string") {
             HoudiniWriteAttribute<openvdb::Name> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "bool") {
             HoudiniWriteAttribute<bool> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "int16") {
             HoudiniWriteAttribute<int16_t> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "int32") {
             HoudiniWriteAttribute<int32_t> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "int64") {
             HoudiniWriteAttribute<int64_t> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "float") {
             HoudiniWriteAttribute<float> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "double") {
             HoudiniWriteAttribute<double> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "vec3i") {
-            HoudiniWriteAttribute<openvdb::math::Vec3<int> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            HoudiniWriteAttribute<Vec3<int> > attribute(*attributeRef.getAttribute());
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "vec3s") {
-            HoudiniWriteAttribute<openvdb::math::Vec3<float> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            HoudiniWriteAttribute<Vec3<float> > attribute(*attributeRef.getAttribute());
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "vec3d") {
-            HoudiniWriteAttribute<openvdb::math::Vec3<double> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            HoudiniWriteAttribute<Vec3<double> > attribute(*attributeRef.getAttribute());
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "quats") {
-            HoudiniWriteAttribute<openvdb::math::Quat<float> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            HoudiniWriteAttribute<Quat<float> > attribute(*attributeRef.getAttribute());
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "quatd") {
-            HoudiniWriteAttribute<openvdb::math::Quat<double> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            HoudiniWriteAttribute<Quat<double> > attribute(*attributeRef.getAttribute());
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "mat4s") {
-            HoudiniWriteAttribute<openvdb::math::Mat4<float> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            HoudiniWriteAttribute<Mat4<float> > attribute(*attributeRef.getAttribute());
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else if (valueType == "mat4d") {
-            HoudiniWriteAttribute<openvdb::math::Mat4<double> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride, includeGroups, excludeGroups, inCoreOnly);
+            HoudiniWriteAttribute<Mat4<double> > attribute(*attributeRef.getAttribute());
+            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
+                includeGroups, excludeGroups, inCoreOnly);
         }
         else {
             throw std::runtime_error("Unknown Attribute Type for Conversion: " + valueType);
@@ -236,7 +264,7 @@ openvdb_houdini::convertPointDataGridToHoudini(
 
 
 void
-openvdb_houdini::pointDataGridSpecificInfoText(std::ostream& infoStr, const openvdb::GridBase& grid)
+pointDataGridSpecificInfoText(std::ostream& infoStr, const openvdb::GridBase& grid)
 {
     typedef openvdb::points::PointDataGrid PointDataGrid;
     typedef openvdb::points::PointDataTree PointDataTree;
@@ -260,7 +288,7 @@ openvdb_houdini::pointDataGridSpecificInfoText(std::ostream& infoStr, const open
 
     std::string viewportGroupName = "";
     if (openvdb::StringMetadata::ConstPtr stringMeta =
-        grid.getMetadata<openvdb::StringMetadata>(openvdb_houdini::META_GROUP_VIEWPORT))
+        grid.getMetadata<openvdb::StringMetadata>(META_GROUP_VIEWPORT))
     {
         viewportGroupName = stringMeta->value();
     }
@@ -347,8 +375,7 @@ openvdb_houdini::pointDataGridSpecificInfoText(std::ostream& infoStr, const open
         const AttributeSet::Descriptor::NameToPosMap& nameToPosMap = descriptor->map();
 
         first = true;
-        for (AttributeSet::Descriptor::ConstIterator it = nameToPosMap.begin(), it_end = nameToPosMap.end();
-                it != it_end; ++it) {
+        for (auto it = nameToPosMap.begin(), it_end = nameToPosMap.end(); it != it_end; ++it) {
             const openvdb::points::AttributeArray& array = iter->constAttributeArray(it->second);
             if (isGroup(array))    continue;
 
@@ -390,6 +417,96 @@ openvdb_houdini::pointDataGridSpecificInfoText(std::ostream& infoStr, const open
         if (first)  infoStr << "<none>";
     }
 }
+
+namespace {
+
+inline int
+lookupGroupInput(const PRM_SpareData *spare)
+{
+    const char  *istring;
+    if (!spare) return 0;
+    istring = spare->getValue("sop_input");
+    return istring ? atoi(istring) : 0;
+}
+
+void
+sopBuildVDBPointsGroupMenu(void *data, PRM_Name *menuEntries, int themenusize,
+    const PRM_SpareData *spare, const PRM_Parm *parm)
+{
+    using openvdb::points::PointDataGrid;
+
+    SOP_Node* sop = CAST_SOPNODE((OP_Node *)data);
+    int inputIndex = lookupGroupInput(spare);
+
+    const GU_Detail* gdp = sop->getInputLastGeo(inputIndex, CHgetEvalTime());
+
+    // const cast as iterator requires non-const access, however data is not modified
+    VdbPrimIterator vdbIt(const_cast<GU_Detail*>(gdp));
+
+    int n_entries = 0;
+
+    for (; vdbIt; ++vdbIt) {
+        GU_PrimVDB* vdbPrim = *vdbIt;
+
+        PointDataGrid::ConstPtr grid =
+                openvdb::gridConstPtrCast<PointDataGrid>(vdbPrim->getConstGridPtr());
+
+        // ignore all but point data grids
+        if (!grid)      continue;
+        auto leafIter = grid->tree().cbeginLeaf();
+        if (!leafIter)  continue;
+
+        const openvdb::points::AttributeSet::Descriptor& descriptor =
+            leafIter->attributeSet().descriptor();
+
+        for (const auto& it : descriptor.groupMap()) {
+            // add each VDB Points group to the menu
+            menuEntries[n_entries].setToken(it.first.c_str());
+            menuEntries[n_entries].setLabel(it.first.c_str());
+            n_entries++;
+        }
+    }
+
+    // zero value ends the menu
+
+    menuEntries[n_entries].setToken(0);
+    menuEntries[n_entries].setLabel(0);
+}
+
+} // unnamed namespace
+
+
+#ifdef _MSC_VER
+
+OPENVDB_HOUDINI_API const PRM_ChoiceList
+VDBPointsGroupMenuInput1(PRM_CHOICELIST_TOGGLE, sopBuildVDBPointsGroupMenu);
+OPENVDB_HOUDINI_API const PRM_ChoiceList
+VDBPointsGroupMenuInput2(PRM_CHOICELIST_TOGGLE, sopBuildVDBPointsGroupMenu);
+OPENVDB_HOUDINI_API const PRM_ChoiceList
+VDBPointsGroupMenuInput3(PRM_CHOICELIST_TOGGLE, sopBuildVDBPointsGroupMenu);
+OPENVDB_HOUDINI_API const PRM_ChoiceList
+VDBPointsGroupMenuInput4(PRM_CHOICELIST_TOGGLE, sopBuildVDBPointsGroupMenu);
+
+OPENVDB_HOUDINI_API const PRM_ChoiceList VDBPointsGroupMenu(PRM_CHOICELIST_TOGGLE,
+    sopBuildVDBPointsGroupMenu);
+
+#else
+
+const PRM_ChoiceList
+VDBPointsGroupMenuInput1(PRM_CHOICELIST_TOGGLE, sopBuildVDBPointsGroupMenu);
+const PRM_ChoiceList
+VDBPointsGroupMenuInput2(PRM_CHOICELIST_TOGGLE, sopBuildVDBPointsGroupMenu);
+const PRM_ChoiceList
+VDBPointsGroupMenuInput3(PRM_CHOICELIST_TOGGLE, sopBuildVDBPointsGroupMenu);
+const PRM_ChoiceList
+VDBPointsGroupMenuInput4(PRM_CHOICELIST_TOGGLE, sopBuildVDBPointsGroupMenu);
+
+const PRM_ChoiceList VDBPointsGroupMenu(PRM_CHOICELIST_TOGGLE,
+    sopBuildVDBPointsGroupMenu);
+
+#endif
+
+} // namespace openvdb_houdini
 
 // Copyright (c) 2012-2017 DreamWorks Animation LLC
 // All rights reserved. This software is distributed under the

--- a/openvdb_houdini/houdini/PointUtils.h
+++ b/openvdb_houdini/houdini/PointUtils.h
@@ -50,7 +50,7 @@
 #include <GA/GA_AIFTuple.h>
 #include <GA/GA_ElementGroup.h>
 #include <GA/GA_Iterator.h>
-
+#include <PRM/PRM_ChoiceList.h>
 
 namespace openvdb_houdini {
 
@@ -594,6 +594,22 @@ void convertPointDataGridToHoudini(
 
 /// @brief If the given grid is a PointDataGrid, add node specific info text to the stream provided
 void pointDataGridSpecificInfoText(std::ostream&, const openvdb::GridBase&);
+
+
+///////////////////////////////////////
+
+
+// VDB Points group name drop-down menu
+
+OPENVDB_HOUDINI_API extern const PRM_ChoiceList VDBPointsGroupMenuInput1;
+OPENVDB_HOUDINI_API extern const PRM_ChoiceList VDBPointsGroupMenuInput2;
+OPENVDB_HOUDINI_API extern const PRM_ChoiceList VDBPointsGroupMenuInput3;
+OPENVDB_HOUDINI_API extern const PRM_ChoiceList VDBPointsGroupMenuInput4;
+
+/// @note   Use this if you have more than 4 inputs, otherwise use
+///         the input specific menus instead which automatically
+///         handle the appropriate spare data settings.
+OPENVDB_HOUDINI_API extern const PRM_ChoiceList VDBPointsGroupMenu;
 
 } // namespace openvdb_houdini
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
@@ -839,8 +839,8 @@ newSopOperator(OP_OperatorTable* table)
 
     {
         const char* items[] = {
-            "vdb", "Houdini Points to VDB Points",
-            "hdk", "VDB Points to Houdini Points",
+            "vdb", "Pack Points into VDB Points",
+            "hdk", "Extract Points from VDB Points",
             nullptr
         };
 
@@ -1186,18 +1186,19 @@ SOP_OpenVDB_Points_Convert::cookMySop(OP_Context& context)
 {
     try {
         hutil::ScopedInputLock lock(*this, context);
-        gdp->clearAndDestroy();
 
         const fpreal time = context.getTime();
-        // Check for particles in the primary (left) input port
-        const GU_Detail* ptGeo = inputGeo(0, context);
 
         if (evalInt("conversion", 0, time) != 0) {
+
+            // Duplicate primary (left) input geometry and convert the VDB points inside
+
+            if (duplicateSourceStealable(0, context) >= UT_ERROR_ABORT) return error();
 
             UT_String groupStr;
             evalString(groupStr, "group", 0, time);
             const GA_PrimitiveGroup *group =
-                matchGroup(const_cast<GU_Detail&>(*ptGeo), groupStr.toStdString());
+                matchGroup(const_cast<GU_Detail&>(*gdp), groupStr.toStdString());
 
             // Extract VDB Point groups to filter
 
@@ -1214,8 +1215,11 @@ SOP_OpenVDB_Points_Convert::cookMySop(OP_Context& context)
             // all attributes should be converted
             const std::vector<std::string> emptyNameVector;
 
-            // Mesh each VDB primitive independently
-            for (hvdb::VdbPrimCIterator vdbIt(ptGeo, group); vdbIt; ++vdbIt) {
+            UT_Array<GEO_Primitive*> primsToDelete;
+            primsToDelete.clear();
+
+            // Convert each VDB primitive independently
+            for (hvdb::VdbPrimIterator vdbIt(gdp, group); vdbIt; ++vdbIt) {
 
                 GU_Detail geo;
 
@@ -1250,10 +1254,19 @@ SOP_OpenVDB_Points_Convert::cookMySop(OP_Context& context)
                 }
 
                 gdp->merge(geo);
+                primsToDelete.append(*vdbIt);
             }
 
+            gdp->deletePrimitives(primsToDelete, true);
             return error();
         }
+
+        // if we're here, we're converting Houdini points to OpenVDB. Clear gdp entirely
+        // before proceeding, then check for particles in the primary (left) input port
+
+        gdp->clearAndDestroy();
+
+        const GU_Detail* ptGeo = inputGeo(0, context);
 
         // Set member data
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
@@ -861,6 +861,7 @@ newSopOperator(OP_OperatorTable* table)
             " (see [specifying volumes|/model/volumes#group])"));
 
     parms.add(hutil::ParmFactory(PRM_STRING, "vdbpointsgroup", "VDB Points Group")
+        .setChoiceList(&hvdb::VDBPointsGroupMenuInput1)
         .setTooltip("Specify VDB Points Groups to use as an input.")
         .setDocumentation(
             "The point group inside the VDB Points primitive to extract\n\n"

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Delete.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Delete.cc
@@ -1,0 +1,230 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+
+/// @file SOP_OpenVDB_Points_Delete.cc
+///
+/// @author Francisco Gochez, Dan Bailey
+///
+/// @brief Delete points that are members of specific groups
+
+#include <openvdb/openvdb.h>
+#include <openvdb/points/PointDataGrid.h>
+#include <openvdb/points/PointDelete.h>
+
+#include <openvdb_houdini/SOP_NodeVDB.h>
+#include <openvdb_houdini/PointUtils.h>
+#include <openvdb_houdini/Utils.h>
+#include <houdini_utils/geometry.h>
+#include <houdini_utils/ParmFactory.h>
+
+using namespace openvdb;
+using namespace openvdb::points;
+using namespace openvdb::math;
+
+namespace hvdb = openvdb_houdini;
+namespace hutil = houdini_utils;
+
+
+////////////////////////////////////////
+
+
+class SOP_OpenVDB_Points_Delete: public hvdb::SOP_NodeVDB
+{
+public:
+    SOP_OpenVDB_Points_Delete(OP_Network*, const char* name, OP_Operator*);
+    ~SOP_OpenVDB_Points_Delete() override = default;
+
+    static OP_Node* factory(OP_Network*, const char* name, OP_Operator*);
+
+protected:
+    OP_ERROR cookMySop(OP_Context&) override;
+
+private:
+    hvdb::Interrupter mBoss;
+}; // class SOP_OpenVDB_Points_Delete
+
+
+////////////////////////////////////////
+
+
+// Build UI and register this operator.
+void
+newSopOperator(OP_OperatorTable* table)
+{
+    openvdb::initialize();
+
+    if (table == nullptr) return;
+
+    hutil::ParmList parms;
+
+    parms.add(hutil::ParmFactory(PRM_STRING, "group", "Group")
+        .setHelpText("Specify a subset of the input point data grids to delete from.")
+        .setChoiceList(&hutil::PrimGroupMenu));
+
+    parms.add(hutil::ParmFactory(PRM_STRING, "vdbpointsgroups", "VDB Points Groups")
+        .setHelpText("Specify VDB points groups to delete.")
+        .setChoiceList(&hvdb::VDBPointsGroupMenuInput1));
+
+    parms.add(hutil::ParmFactory(PRM_TOGGLE, "invert", "Invert")
+        .setDefault(PRMzeroDefaults)
+        .setHelpText("Invert point deletion so that points not belonging to any of the \
+            groups will be deleted."));
+
+    //////////
+    // Register this operator.
+
+    hvdb::OpenVDBOpFactory("OpenVDB Points Delete",
+        SOP_OpenVDB_Points_Delete::factory, parms, *table)
+        .addInput("VDB Points")
+        .setDocumentation("\
+#icon: COMMON/openvdb\n\
+#tags: vdb\n\
+\n\
+\"\"\"Delete points that are members of specific groups.\"\"\"\n\
+\n\
+@overview\n\
+\n\
+The OpenVDB Points Delete SOP allows deletion of points that are members\n\
+of a supplied group(s).\n\
+An invert toggle may be enabled to allow deleting points that are not\n\
+members of the supplied group(s).\n\
+\n\
+@related\n\
+- [OpenVDB Points Convert|Node:sop/DW_OpenVDBPointsConvert]\n\
+- [OpenVDB Points Group|Node:sop/DW_OpenVDBPointsGroup]\n\
+\n\
+@examples\n\
+\n\
+See [openvdb.org|http://www.openvdb.org/download/] for source code\n\
+and usage examples.\n");
+}
+
+////////////////////////////////////////
+
+
+OP_Node*
+SOP_OpenVDB_Points_Delete::factory(OP_Network* net,
+    const char* name, OP_Operator* op)
+{
+    return new SOP_OpenVDB_Points_Delete(net, name, op);
+}
+
+
+SOP_OpenVDB_Points_Delete::SOP_OpenVDB_Points_Delete(OP_Network* net,
+    const char* name, OP_Operator* op)
+    : hvdb::SOP_NodeVDB(net, name, op)
+{
+}
+
+
+////////////////////////////////////////
+
+
+OP_ERROR
+SOP_OpenVDB_Points_Delete::cookMySop(OP_Context& context)
+{
+    try {
+        hutil::ScopedInputLock lock(*this, context);
+        // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
+        if (duplicateSourceStealable(0, context) >= UT_ERROR_ABORT) return error();
+
+        UT_String groupStr;
+        evalString(groupStr, "vdbpointsgroups", 0, context.getTime());
+
+        const std::string groups(groupStr.toStdString());
+
+        // early exit if the VDB points group field is empty
+        if (groups.empty()) return error();
+
+        UT_AutoInterrupt progress("Processing points group deletion");
+
+        const bool invert = evalInt("invert", 0, context.getTime());
+
+        // select Houdini primitive groups we wish to use
+        UT_String houdiniPrimGroups;
+        evalString(houdiniPrimGroups, "group", 0, context.getTime());
+
+        const GA_PrimitiveGroup *group =
+            matchGroup(*gdp, houdiniPrimGroups.toStdString());
+
+        hvdb::VdbPrimIterator vdbIt(gdp, group);
+
+        for (; vdbIt; ++vdbIt) {
+            if (progress.wasInterrupted()) {
+                throw std::runtime_error("processing was interrupted");
+            }
+            GU_PrimVDB* vdbPrim = *vdbIt;
+
+            PointDataGrid::ConstPtr inputGrid =
+                    openvdb::gridConstPtrCast<PointDataGrid>(vdbPrim->getConstGridPtr());
+
+            // early exit if the grid is of the wrong type
+            if (!inputGrid)    continue;
+
+            // early exit if the tree is empty
+            auto leafIter = inputGrid->tree().cbeginLeaf();
+            if (!leafIter)    continue;
+
+            // extract names of all selected VDB groups
+
+            std::vector<std::string> pointGroups;
+
+            // the "exclude groups" parameter to parseNames is not used in this context,
+            // so we disregard it by storing it in a temporary variable
+
+            std::vector<std::string> tmp;
+
+            AttributeSet::Descriptor::parseNames(pointGroups, tmp, groups);
+
+            // determine in any of the requested groups are actually present in the tree
+
+            const AttributeSet::Descriptor& descriptor = leafIter->attributeSet().descriptor();
+            const bool hasPointsToDrop = std::any_of(pointGroups.begin(), pointGroups.end(),
+                                                    [&descriptor](const std::string &group) ->
+                                                        bool{return descriptor.hasGroup(group);});
+
+            if (!hasPointsToDrop)    continue;
+
+            // deep copy the VDB tree if it is not already unique
+            vdbPrim->makeGridUnique();
+
+            PointDataGrid& outputGrid = UTvdbGridCast<PointDataGrid>(vdbPrim->getGrid());
+            deleteFromGroups(outputGrid.tree(), pointGroups, invert);
+        }
+
+    } catch (const std::exception& e) {
+        addError(SOP_MESSAGE, e.what());
+    }
+    return error();
+}
+
+// Copyright (c) 2012-2017 DreamWorks Animation LLC
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Group.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Group.cc
@@ -86,6 +86,11 @@ struct GroupParms {
     bool                          mEnableViewport     = false;
     bool                          mAddViewport        = false;
     std::string                   mViewportGroupName  = "";
+    // drop groups
+    bool                          mDropAllGroups      = false;
+    std::vector<std::string>      mDropIncludeGroups;
+    std::vector<std::string>      mDropExcludeGroups;
+
 };
 
 } // namespace
@@ -145,13 +150,14 @@ newSopOperator(OP_OperatorTable* table)
             "A subset of the input VDB Points primitives to be processed"
             " (see [specifying volumes|/model/volumes#group])"));
 
-    parms.add(hutil::ParmFactory(PRM_STRING, "vdbpointsgroup", "VDB Points Group")
-        .setTooltip(
-            "Specify an existing internal group in the VDB Points primitive"
-            " to use as a starting point for a new group."));
-
     parms.beginSwitcher("tabMenu1");
     parms.addFolder("Create");
+
+    parms.add(hutil::ParmFactory(PRM_STRING, "vdbpointsgroup", "Filter by VDB Group")
+        .setChoiceList(&hvdb::VDBPointsGroupMenuInput1)
+        .setTooltip("Create a new VDB points group as a subset of an existing VDB points group(s)."));
+
+    parms.add(houdini_utils::ParmFactory(PRM_LABEL, "spacer1", ""));
 
     // Toggle to enable creation
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "enablecreate", "Enable")
@@ -270,6 +276,14 @@ newSopOperator(OP_OperatorTable* table)
 
     parms.endSwitcher();
 
+    parms.addFolder("Delete");
+
+    parms.add(hutil::ParmFactory(PRM_STRING, "deletegroups", "Point Groups")
+        .setDefault(0, "")
+        .setHelpText("A space-delimited list of groups to delete.  This will delete the selected groups but \
+                     will not delete the points contained in them.")
+        .setChoiceList(&hvdb::VDBPointsGroupMenuInput1));
+
     parms.addFolder("Viewport");
 
     parms.add(hutil::ParmFactory(PRM_TOGGLE, "enableviewport", "Enable")
@@ -348,6 +362,7 @@ SOP_OpenVDB_Points_Group::updateParmsFlags()
     const bool sdfmax = evalInt("enablesdfmax", 0, 0);
     const bool viewportadd = evalInt("viewportoperation", 0, 0) == 0;
 
+    changed |= enableParm("vdbpointsgroup", creation);
     changed |= enableParm("groupname", creation);
     changed |= enableParm("enablenumber", creation);
     changed |= enableParm("numbermode", creation && number);
@@ -397,8 +412,6 @@ SOP_OpenVDB_Points_Group::SOP_OpenVDB_Points_Group(OP_Network* net,
 OP_ERROR
 SOP_OpenVDB_Points_Group::cookMySop(OP_Context& context)
 {
-    using PointDataGrid = openvdb::points::PointDataGrid;
-
     try {
         hutil::ScopedInputLock lock(*this, context);
         // This does a shallow copy of VDB-grids and deep copy of native Houdini primitives.
@@ -437,10 +450,46 @@ SOP_OpenVDB_Points_Group::cookMySop(OP_Context& context)
                         removeViewportMetadata(outputGrid);
                     }
                 }
+            }
+
+            const AttributeSet::Descriptor& descriptor = leafIter->attributeSet().descriptor();
+
+            std::vector<std::string> groupsToDrop;
+
+            bool hasGroupsToDrop = !descriptor.groupMap().empty();
+            if (hasGroupsToDrop) {
+                // exclude groups mode
+                if (!parms.mDropExcludeGroups.empty()) {
+                    // if any groups are to be excluded, ignore those to be included
+                    // and rebuild them
+                    for (const auto& it: descriptor.groupMap()) {
+                        if (std::find(  parms.mDropExcludeGroups.begin(),
+                                        parms.mDropExcludeGroups.end(), it.first) ==
+                                        parms.mDropExcludeGroups.end()) {
+                            groupsToDrop.push_back(it.first);
+                        }
+                    }
+                }
+                else if (!parms.mDropAllGroups) {
+                    // if any groups are to be included, intersect them with groups that exist
+                    for (const auto& groupName : parms.mDropIncludeGroups) {
+                        if (descriptor.hasGroup(groupName)) {
+                            groupsToDrop.push_back(groupName);
+                        }
+                    }
+                }
+            }
+
+            if (hasGroupsToDrop)    hasGroupsToDrop = parms.mDropAllGroups || !groupsToDrop.empty();
+
+            // If we are not creating groups and there are no groups to drop (due to an empty list or because none of
+            // the chosen ones were actually present), we can continue the loop early here
+            if(!parms.mEnable && !hasGroupsToDrop) {
                 continue;
             }
 
             // Evaluate grid-specific UI parameters
+
             if (evalGridGroupParms(pointDataGrid, context, parms) >= UT_ERROR_ABORT)
                 return error();
 
@@ -450,13 +499,24 @@ SOP_OpenVDB_Points_Group::cookMySop(OP_Context& context)
             auto&& outputGrid = UTvdbGridCast<PointDataGrid>(vdbPrim->getGrid());
 
             // filter and create the point group in the grid
-            performGroupFiltering(outputGrid, parms);
+            if (parms.mEnable) {
+                performGroupFiltering(outputGrid, parms);
+            }
+
+            // drop groups
+            if (parms.mDropAllGroups) {
+                dropGroups(outputGrid.tree());
+            }
+            else if (!groupsToDrop.empty()) {
+                dropGroups(outputGrid.tree(), groupsToDrop);
+            }
 
             // attach group viewport metadata to the grid
             if (parms.mEnableViewport) {
                 if (parms.mAddViewport)     setViewportMetadata(outputGrid, parms);
                 else                        removeViewportMetadata(outputGrid);
             }
+
         }
 
         return error();
@@ -682,6 +742,27 @@ SOP_OpenVDB_Points_Group::evalGroupParms(OP_Context& context, GroupParms& parms)
 
     parms.mViewportGroupName = viewportGroupName;
 
+    // group deletion
+
+    UT_String groupsToDropNamesStr;
+    evalString(groupsToDropNamesStr, "deletegroups", 0, time);
+
+    AttributeSet::Descriptor::parseNames(parms.mDropIncludeGroups, parms.mDropExcludeGroups,
+        parms.mDropAllGroups, groupsToDropNamesStr.toStdString());
+
+    if (parms.mDropAllGroups) {
+        // include groups only apply if not also deleting all groups
+        parms.mDropIncludeGroups.clear();
+        // if exclude groups is not empty, don't delete all groups
+        if (!parms.mDropExcludeGroups.empty()) {
+            parms.mDropAllGroups = false;
+        }
+    }
+    else {
+        // exclude groups only apply if also deleting all groups
+        parms.mDropExcludeGroups.clear();
+    }
+
     return error();
 }
 
@@ -701,52 +782,55 @@ SOP_OpenVDB_Points_Group::evalGridGroupParms(const PointDataGrid& grid,
 
     // check new group doesn't already exist
 
-    if (descriptor.hasGroup(parms.mGroupName)) {
-        addError(SOP_MESSAGE, ("Cannot create duplicate group - " + parms.mGroupName).c_str());
-        return error();
-    }
+    if (parms.mEnable) {
 
-    // group
-
-    if (parms.mOpGroup)
-    {
-        for (const std::string& name : parms.mIncludeGroups) {
-            if (!descriptor.hasGroup(name)) {
-                addError(SOP_MESSAGE, ("Unable to find VDB Points group - " + name).c_str());
-                return error();
-            }
-        }
-
-        for (const std::string& name : parms.mExcludeGroups) {
-            if (!descriptor.hasGroup(name)) {
-                addError(SOP_MESSAGE, ("Unable to find VDB Points group - " + name).c_str());
-                return error();
-            }
-        }
-    }
-
-    // number
-
-    if (parms.mHashMode)
-    {
-        // retrieve percent attribute type (if it exists)
-
-        const size_t index = descriptor.find(parms.mHashAttribute);
-
-        if (index == AttributeSet::INVALID_POS) {
-            addError(SOP_MESSAGE, ("Unable to find attribute - " + parms.mHashAttribute).c_str());
+        if (descriptor.hasGroup(parms.mGroupName)) {
+            addError(SOP_MESSAGE, ("Cannot create duplicate group - " + parms.mGroupName).c_str());
             return error();
         }
 
-        parms.mHashAttributeIndex = index;
-        const std::string attributeType = descriptor.valueType(index);
+        // group
 
-        if (attributeType == "int32")       parms.mOpHashI = true;
-        else if (attributeType == "int64")  parms.mOpHashL = true;
-        else {
-            addError(SOP_MESSAGE, ("Unsupported attribute type for percent attribute filtering - "
-                + attributeType).c_str());
-            return error();
+        if (parms.mOpGroup)
+        {
+            for (const std::string& name : parms.mIncludeGroups) {
+                if (!descriptor.hasGroup(name)) {
+                    addError(SOP_MESSAGE, ("Unable to find VDB Points group - " + name).c_str());
+                    return error();
+                }
+            }
+
+            for (const std::string& name : parms.mExcludeGroups) {
+                if (!descriptor.hasGroup(name)) {
+                    addError(SOP_MESSAGE, ("Unable to find VDB Points group - " + name).c_str());
+                    return error();
+                }
+            }
+        }
+
+        // number
+
+        if (parms.mHashMode)
+        {
+            // retrieve percent attribute type (if it exists)
+
+            const size_t index = descriptor.find(parms.mHashAttribute);
+
+            if (index == AttributeSet::INVALID_POS) {
+                addError(SOP_MESSAGE, ("Unable to find attribute - " + parms.mHashAttribute).c_str());
+                return error();
+            }
+
+            parms.mHashAttributeIndex = index;
+            const std::string attributeType = descriptor.valueType(index);
+
+            if (attributeType == "int32")       parms.mOpHashI = true;
+            else if (attributeType == "int64")  parms.mOpHashL = true;
+            else {
+                addError(SOP_MESSAGE, ("Unsupported attribute type for percent attribute filtering - "
+                    + attributeType).c_str());
+                return error();
+            }
         }
     }
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Group.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Group.cc
@@ -322,6 +322,7 @@ with an [OpenVDB Points Convert node|Node:sop/DW_OpenVDBPointsConvert].\n\
 \n\
 @related\n\
 - [OpenVDB Points Convert|Node:sop/DW_OpenVDBPointsConvert]\n\
+- [OpenVDB Points Delete|Node:sop/DW_OpenVDBPointsDelete]\n\
 \n\
 @examples\n\
 \n\


### PR DESCRIPTION
Add support for deleting points and groups and introduce a new OpenVDB Points Delete SOP. Improvements to OpenVDB Points Convert SOP include no longer deleting non-VDB primitives on conversion, introducing stealable behaviour and auto-population of group field drop-downs.