### PR TITLE
Make OpenVDB Clip SOP mask input optional for camera mode

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Clip.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Clip.cc
@@ -142,7 +142,7 @@ Mask VDB:\n\
 
     hvdb::OpenVDBOpFactory("OpenVDB Clip", SOP_OpenVDB_Clip::factory, parms, *table)
         .addInput("VDBs")
-        .addInput("Mask VDB or bounding geometry")
+        .addOptionalInput("Mask VDB or bounding geometry")
         .setObsoleteParms(obsoleteParms)
         .setDocumentation("\
 #icon: COMMON/openvdb\n\
@@ -458,6 +458,10 @@ SOP_OpenVDB_Clip::cookMySop(OP_Context& context)
                 clipBox.max()[1] = box.ymax();
                 clipBox.max()[2] = box.zmax();
             }
+        }
+        else {
+            addError(SOP_MESSAGE, "Not enough sources specified.");
+            return UT_ERROR_ABORT;
         }
 
         // Get the group of grids to process.


### PR DESCRIPTION
Minor tweak to the OpenVDB Clip SOP so that the mask input isn't required when frustum clipping in camera mode.