### PR TITLE
Adding support for PointDataGrid VDBs as masks in OpenVDB SOPs

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Analysis.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Analysis.cc
@@ -382,8 +382,15 @@ SOP_OpenVDB_Analysis::cookMySop(OP_Context& context)
             hvdb::VdbPrimCIterator maskIt(maskGeo, maskGroup);
             if (maskIt) {
                 MaskOp op;
-                UTvdbProcessTypedGridTopology(maskIt->getStorageType(), maskIt->getGrid(), op);
-                maskGrid = op.mMaskGrid;
+
+                if (UTvdbProcessTypedGridTopology(maskIt->getStorageType(), maskIt->getGrid(), op)) {
+                    maskGrid = op.mMaskGrid;
+                }
+# if UT_MAJOR_VERSION_INT >= 16
+                else if(UTvdbProcessTypedGridPoint(maskIt->getStorageType(), maskIt->getGrid(), op)) {
+                    maskGrid = op.mMaskGrid;
+                }
+#endif
             }
 
             if (!maskGrid) addWarning(SOP_MESSAGE, "Mask VDB not found.");
@@ -472,7 +479,7 @@ SOP_OpenVDB_Analysis::cookMySop(OP_Context& context)
                 std::ostringstream ss;
                 ss << "Can't compute " << sOpName[whichOp] << " from grid";
                 if (inGridName.isstring()) ss << " " << inGridName;
-                ss << " of type " << vdb->getGrid().valueType();
+                ss << " of type " << UTvdbGetGridTypeString(vdb->getGrid());
                 addWarning(SOP_MESSAGE, ss.str().c_str());
             }
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Clip.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Clip.cc
@@ -317,8 +317,14 @@ struct MaskClipOp
         if (mask) {
             // Dispatch on the mask grid type, now that the source grid type is resolved.
             MaskClipDispatchOp<GridType> op(grid, inside);
-            UTvdbProcessTypedGridTopology(UTvdbGetGridType(*mask), *mask, op);
-            outputGrid = op.outputGrid;
+            if (UTvdbProcessTypedGridTopology(UTvdbGetGridType(*mask), *mask, op)) {
+                outputGrid = op.outputGrid;
+            }
+# if UT_MAJOR_VERSION_INT >= 16
+            else if (UTvdbProcessTypedGridPoint(UTvdbGetGridType(*mask), *mask, op)) {
+                outputGrid = op.outputGrid;
+            }
+#endif
         }
     }
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Create.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Create.cc
@@ -1042,7 +1042,18 @@ SOP_OpenVDB_Create::createMaskGrid(const GU_PrimVDB* refVdb,
 
     cvdb::MaskGrid::Ptr maskGrid;
     GridConvertToMask op(maskGrid);
-    GEOvdbProcessTypedGridTopology(*refVdb, op);
+    if (GEOvdbProcessTypedGridTopology(*refVdb, op)) {
+        maskGrid->setTransform(refVdb->getGrid().transform().copy());
+    }
+#if UT_MAJOR_VERSION_INT >= 16
+    else if (GEOvdbProcessTypedGridPoint(*refVdb, op)) {
+        maskGrid->setTransform(refVdb->getGrid().transform().copy());
+    }
+#endif
+    else {
+        throw std::runtime_error("No valid reference grid found");
+    }
+
     maskGrid->setTransform(refVdb->getGrid().transform().copy());
 
     if (!mNeedsResampling)

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Prune.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Prune.cc
@@ -234,7 +234,11 @@ SOP_OpenVDB_Prune::cookMySop(OP_Context& context)
             }
 
             GU_PrimVDB* vdbPrim = *it;
-            GEOvdbProcessTypedGridTopology(*vdbPrim, pruneOp);
+            if (!GEOvdbProcessTypedGridTopology(*vdbPrim, pruneOp)) {
+#if UT_MAJOR_VERSION_INT >= 16
+               GEOvdbProcessTypedGridPoint(*vdbPrim, pruneOp);
+#endif
+            }
         }
     } catch (std::exception& e) {
         addError(SOP_MESSAGE, e.what());

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Rasterize_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Rasterize_Points.cc
@@ -2668,7 +2668,12 @@ applyClippingMask(PointIndexGridCollection::BoolTreeType& mask, RasterizationSet
         GridTopologyClipOp<PointIndexGridCollection::BoolTreeType>
             op(mask, *settings.transform, settings.invertMask);
 
-        UTvdbProcessTypedGridTopology(UTvdbGetGridType(*settings.maskGrid), *settings.maskGrid, op);
+        if (!UTvdbProcessTypedGridTopology(UTvdbGetGridType(*settings.maskGrid), *settings.maskGrid, op)) {
+#if UT_MAJOR_VERSION_INT >= 16
+            UTvdbProcessTypedGridPoint(UTvdbGetGridType(*settings.maskGrid), *settings.maskGrid, op);
+#endif
+
+        }
     }
 }
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Remove_Divergence.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Remove_Divergence.cc
@@ -968,8 +968,13 @@ SOP_OpenVDB_Remove_Divergence::cookMySop(OP_Context& context)
                         parms.colliderType = CT_STATIC;
                         ColliderMaskOp op;
                         op.mask = ColliderMaskGrid::create();
-                        UTvdbProcessTypedGridTopology(UTvdbGetGridType(*parms.colliderGrid),
-                            *parms.colliderGrid, op);
+                        if (!UTvdbProcessTypedGridTopology(UTvdbGetGridType(*parms.colliderGrid),
+                            *parms.colliderGrid, op)) {
+#if UT_MAJOR_VERSION_INT >= 16
+                            UTvdbProcessTypedGridPoint(UTvdbGetGridType(*parms.colliderGrid),
+                                                        *parms.colliderGrid, op);
+#endif
+                        }
                         parms.colliderGrid = op.mask;
                     }
                 }

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Resample.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Resample.cc
@@ -44,6 +44,7 @@
 #include <openvdb_houdini/UT_VDBUtils.h> // for UTvdbProcessTypedGridReal()
 #include <openvdb_houdini/SOP_NodeVDB.h>
 #include <openvdb/openvdb.h>
+#include <openvdb/points/PointDataGrid.h>
 #include <openvdb/tools/GridTransformer.h>
 #include <openvdb/tools/LevelSetRebuild.h>
 #include <openvdb/tools/VectorTransformer.h> // for transformVectors()
@@ -485,6 +486,11 @@ SOP_OpenVDB_Resample::cookMySop(OP_Context& context)
             if (progress.wasInterrupted()) throw std::runtime_error("Was Interrupted");
 
             GU_PrimVDB* vdb = *it;
+
+            if (vdb->getGrid().isType<openvdb::points::PointDataGrid>()) {
+                addWarning(SOP_MESSAGE, "Point data grids cannot currently be resampled, skipping");
+                continue;
+            }
 
             const UT_VDBType valueType = vdb->getStorageType();
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
@@ -368,7 +368,11 @@ SOP_OpenVDB_Scatter::cookMySop(OP_Context& context)
                 if (interior && isSignedDistance) {
                     processLSInterior(gridType, grid, scatter);
                 } else {
-                    UTvdbProcessTypedGridScalar(gridType, grid, scatter);
+                    if (!UTvdbProcessTypedGridScalar(gridType, grid, scatter)) {
+#if UT_MAJOR_VERSION_INT >= 16
+                        UTvdbProcessTypedGridPoint(gridType, grid, scatter);
+#endif
+                    }
                 }
 
                 if (verbose) scatter.print(gridName);
@@ -399,7 +403,11 @@ SOP_OpenVDB_Scatter::cookMySop(OP_Context& context)
                     if (interior && isSignedDistance) {
                         processLSInterior(gridType, grid, scatter);
                     } else {
-                        UTvdbProcessTypedGridTopology(gridType, grid, scatter);
+                        if (!UTvdbProcessTypedGridTopology(gridType, grid, scatter)) {
+#if UT_MAJOR_VERSION_INT >= 16
+                            UTvdbProcessTypedGridPoint(gridType, grid, scatter);
+#endif
+                        }
                     }
 
                     if (verbose) scatter.print(gridName);
@@ -413,7 +421,11 @@ SOP_OpenVDB_Scatter::cookMySop(OP_Context& context)
                 if (interior && isSignedDistance) {
                     processLSInterior(gridType, grid, scatter);
                 } else {
-                    UTvdbProcessTypedGridTopology(gridType, grid, scatter);
+                    if (!UTvdbProcessTypedGridTopology(gridType, grid, scatter)) {
+#if UT_MAJOR_VERSION_INT >= 16
+                        UTvdbProcessTypedGridPoint(gridType, grid, scatter);
+#endif
+                    }
                 }
 
                 if (verbose) scatter.print(gridName);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Segment.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Segment.cc
@@ -38,6 +38,7 @@
 #include <openvdb_houdini/SOP_NodeVDB.h>
 #include <openvdb_houdini/Utils.h>
 
+#include <openvdb/points/PointDataGrid.h>
 #include <openvdb/tools/LevelSetUtil.h>
 
 
@@ -326,6 +327,11 @@ SOP_OpenVDB_Segment::cookMySop(OP_Context& context)
             if (boss.wasInterrupted()) break;
 
             const GU_PrimVDB* vdb = vdbIt.getPrimitive();
+
+            if (vdb->getGrid().isType<openvdb::points::PointDataGrid>()) {
+                addWarning(SOP_MESSAGE, "VDB points grids cannot currently be segmented and will be ignored.");
+                continue;
+            }
 
             const openvdb::GridClass gridClass = vdb->getGrid().getGridClass();
             if (gridClass == openvdb::GRID_LEVEL_SET) {


### PR DESCRIPTION
In Houdini 16, the UTvdbProcessTypedGridTopology() / GEOvdbProcessTypedGridTopology() methods do not include PointDataGrids. However many of the OpenVDB SOPs assume that all VDBs supported in Houdini are handled by this method, which in the worst cases (such as OpenVDB Create SOP) can cause a seg fault through dereferencing an invalid grid.

This patch adds PointDataGrid mask or topology support to the following SOPs  - Analysis, Clip, Create, Prune, Rasterize, Remove Divergence and Scatter. It also adds a warning to the Segment and Resample SOPs which are yet to be extended to support PointDataGrids.