### PR TITLE
Update Travis to add ABI=5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,8 @@ compiler: clang
 
 # Setup environment variables for different concurrent builds
 env:
-  # Build and run unit tests for ABI=3 and ABI=4
+  # Build and run unit tests for ABI={3,4,5}
+  - ABI=5 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
   - ABI=4 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
 
@@ -53,13 +54,16 @@ env:
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=15.5
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=15.0
 
-  # Build and run unit tests for ABI=3 and ABI=4 with Blosc disabled
+  # Build and run unit tests for ABI={3,4,5} with Blosc disabled
+  - ABI=5 BLOSC=no RELEASE=yes HOUDINI_MAJOR=none
   - ABI=4 BLOSC=no RELEASE=yes HOUDINI_MAJOR=none
   - ABI=3 BLOSC=no RELEASE=yes HOUDINI_MAJOR=none
 
-  # Build (but don't run) unit tests in debug mode for ABI=3 and ABI=4 with and without Blosc
+  # Build (but don't run) unit tests in debug mode for ABI={3,4,5} with and without Blosc
+  - ABI=5 BLOSC=yes RELEASE=no HOUDINI_MAJOR=none
   - ABI=4 BLOSC=yes RELEASE=no HOUDINI_MAJOR=none
   - ABI=3 BLOSC=yes RELEASE=no HOUDINI_MAJOR=none
+  - ABI=5 BLOSC=no RELEASE=no HOUDINI_MAJOR=none
   - ABI=4 BLOSC=no RELEASE=no HOUDINI_MAJOR=none
   - ABI=3 BLOSC=no RELEASE=no HOUDINI_MAJOR=none
 

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -34,7 +34,7 @@
 # TASK (install/script):
 #        * install (downloading and building all dependent libraries)
 #        * script (building OpenVDB and executing unit tests)
-# ABI (3/4) - the ABI version of OpenVDB
+# ABI (3/4/5) - the ABI version of OpenVDB
 # BLOSC (yes/no) - to build with Blosc support
 # RELEASE (yes/no) - to build in release or debug mode
 # HOUDINI_MAJOR (15.0/15.5/16.0) - the major version of Houdini
@@ -118,33 +118,17 @@ elif [ "$TASK" = "script" ]; then
     if [ "$HOUDINI_MAJOR" = "none" ]; then
         # release mode - build and run OpenVDB unit tests
         # debug mode - build OpenVDB unit tests
-        if [ "$ABI" = "3" ]; then
-            if [ "$BLOSC" = "yes" ]; then
-                if [ "$RELEASE" = "yes" ]; then
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test abi=3 -j4
-                else
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi=3 debug=yes -j4
-                fi
+        if [ "$BLOSC" = "yes" ]; then
+            if [ "$RELEASE" = "yes" ]; then
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test abi="$ABI" -j4
             else
-                if [ "$RELEASE" = "yes" ]; then
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS test abi=3 -j4
-                else
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi=3 debug=yes -j4
-                fi
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install abi="$ABI" debug=yes -j4
             fi
         else
-            if [ "$BLOSC" = "yes" ]; then
-                if [ "$RELEASE" = "yes" ]; then
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS test -j4
-                else
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $STANDALONE_BLOSC_ARGS install debug=yes -j4
-                fi
+            if [ "$RELEASE" = "yes" ]; then
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS test abi="$ABI" -j4
             else
-                if [ "$RELEASE" = "yes" ]; then
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS test -j4
-                else
-                    make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install debug=yes -j4
-                fi
+                make -C openvdb $COMMON_ARGS $STANDALONE_ARGS $NO_BLOSC_ARGS install abi="$ABI" debug=yes -j4
             fi
         fi
     else


### PR DESCRIPTION
Add these additional options:

* Build and run unit tests using ABI=5 (opt+blosc)
* Build using ABI=5 (opt+no blosc)
* Build using ABI=5 (debug+blosc)
* Build using ABI=5 (debug+no blosc)

Not sure we're ready to deprecate ABI=3 in Travis just yet, but that's probably the next change.