### PR TITLE
Add forwards-compatibility reading for ABI=5

### DIFF
--- a/openvdb/points/AttributeSet.h
+++ b/openvdb/points/AttributeSet.h
@@ -265,6 +265,21 @@ private:
 ////////////////////////////////////////
 
 
+/// A container for ABI=5 to help ease introduction of upcoming features
+#if OPENVDB_ABI_VERSION_NUMBER >= 5
+namespace future {
+    class Container
+    {
+        class Element { };
+        std::vector<std::shared_ptr<Element>> mElements;
+    };
+}
+#endif
+
+
+////////////////////////////////////////
+
+
 /// @brief  An immutable object that stores name, type and AttributeSet position
 ///         for a constant collection of attribute arrays.
 /// @note   The attribute name is actually mutable, but the attribute type
@@ -453,7 +468,15 @@ private:
     std::vector<NamePair>       mTypes;
     NameToPosMap                mGroupMap;
     MetaMap                     mMetadata;
+#if OPENVDB_ABI_VERSION_NUMBER >= 5
+    // as this change is part of an ABI change, there's no good reason to reduce the reserved
+    // space aside from keeping the memory size of an AttributeSet the same for convenience
+    // (note that this assumes a typical three-pointer implementation for std::vector)
+    future::Container           mFutureContainer;   // occupies 3 reserved slots
+    int64_t                     mReserved[5];       // for future use
+#else
     int64_t                     mReserved[8];       // for future use
+#endif
 }; // class Descriptor
 
 } // namespace points


### PR DESCRIPTION
This will ease the introduction of planned future features by initialising a member variable correctly and adding an extension mechanism to the reading of PointDataLeafNodes for future use.