### PR TITLE
Add tools/Mask.h to the include list of the Makefile so it is installed

### DIFF
--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -378,6 +378,7 @@ INCLUDE_NAMES := \
     tools/LevelSetSphere.h \
     tools/LevelSetTracker.h \
     tools/LevelSetUtil.h \
+    tools/Mask.h \
     tools/MeshToVolume.h \
     tools/Morphology.h \
     tools/MultiResGrid.h \


### PR DESCRIPTION
Makefile build didn't get the Mask.h so it wasn't properly installed in our Make builds.