### PR TITLE
Avoid having duplicate copies of the grid when invoking makeGridUnique.

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Remove_Divergence.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Remove_Divergence.cc
@@ -990,7 +990,10 @@ SOP_OpenVDB_Remove_Divergence::cookMySop(OP_Context& context)
             if (velocityType == UT_VDB_VEC3F || velocityType == UT_VDB_VEC3D) {
                 // Found a vector-valued input grid.
                 ++numGridsProcessed;
+
+		parms.velocityGrid.reset();
                 vdbIt->makeGridUnique();
+		parms.velocityGrid = vdbIt->getGridPtr();
 
                 const openvdb::math::Transform& xform = parms.velocityGrid->constTransform();
 


### PR DESCRIPTION
The makeGridUnique function on GU_PrimVDB asserts that there is only a single reference on
debug builds.