### PR TITLE
Create a matchGroup() version that takes a const GU_Detail

### DIFF
--- a/openvdb_houdini/houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.cc
@@ -209,9 +209,28 @@ SOP_NodeVDB::matchGroup(GU_Detail& aGdp, const std::string& pattern)
     if (!pattern.empty()) {
         // If a pattern was provided, try to match it.
 #if (UT_MAJOR_VERSION_INT >= 15)
-        group = parsePrimitiveGroups(pattern.c_str(), GroupCreator(&aGdp));
+        group = parsePrimitiveGroups(pattern.c_str(), GroupCreator(&aGdp, false));
 #else
         group = parsePrimitiveGroups(pattern.c_str(), &aGdp);
+#endif
+        if (!group) {
+            // Report an error if the pattern didn't match.
+            throw std::runtime_error(("Invalid group (" + pattern + ")").c_str());
+        }
+    }
+    return group;
+}
+
+const GA_PrimitiveGroup*
+SOP_NodeVDB::matchGroup(const GU_Detail& aGdp, const std::string& pattern)
+{
+    const GA_PrimitiveGroup* group = NULL;
+    if (!pattern.empty()) {
+        // If a pattern was provided, try to match it.
+#if (UT_MAJOR_VERSION_INT >= 15)
+        group = parsePrimitiveGroups(pattern.c_str(), GroupCreator(&aGdp));
+#else
+        group = parsePrimitiveGroups(pattern.c_str(), const_cast<GU_Detail*>(&aGdp));
 #endif
         if (!group) {
             // Report an error if the pattern didn't match.

--- a/openvdb_houdini/houdini/SOP_NodeVDB.h
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.h
@@ -103,7 +103,10 @@ protected:
     /// @throw std::runtime_error if the pattern is nonempty but doesn't match any group.
     /// @todo This is a wrapper for SOP_Node::parsePrimitiveGroups(), so it needs access
     /// to a SOP_Node instance.  But it probably doesn't need to be a SOP_NodeVDB method.
+    ///@{
     const GA_PrimitiveGroup* matchGroup(GU_Detail&, const std::string& pattern);
+    const GA_PrimitiveGroup* matchGroup(const GU_Detail&, const std::string& pattern);
+    ///@}
 
     //@{
     /// @brief Evaluate a vector-valued parameter.

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Advect.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Advect.cc
@@ -584,7 +584,7 @@ SOP_OpenVDB_Advect::evalAdvectionParms(OP_Context& context, AdvectionParms& parm
 
     evalString(str, "velGroup", 0, now);
     const GA_PrimitiveGroup *velGroup =
-        matchGroup(const_cast<GU_Detail&>(*velGeo), str.toStdString());
+        matchGroup(*velGeo, str.toStdString());
 
     hvdb::VdbPrimCIterator it(velGeo, velGroup);
     if (it) {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Advect_Points.cc
@@ -941,7 +941,7 @@ SOP_OpenVDBAdvectPoints::evalAdvectionParms(OP_Context& context, AdvectionParms&
 
         evalString(str, "velGroup", 0, now);
         const GA_PrimitiveGroup *velGroup =
-            matchGroup(const_cast<GU_Detail&>(*velGeo), str.toStdString());
+            matchGroup(*velGeo, str.toStdString());
 
         hvdb::VdbPrimCIterator it(velGeo, velGroup);
         parms.mVelPrim = *it;
@@ -988,7 +988,7 @@ SOP_OpenVDBAdvectPoints::evalAdvectionParms(OP_Context& context, AdvectionParms&
 
         evalString(str, "cptGroup", 0, now);
         const GA_PrimitiveGroup *cptGroup =
-            matchGroup(const_cast<GU_Detail&>(*cptGeo), str.toStdString());
+            matchGroup(*cptGeo, str.toStdString());
 
         hvdb::VdbPrimCIterator it(cptGeo, cptGroup);
         parms.mCptPrim = *it;

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Combine.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Combine.cc
@@ -653,7 +653,7 @@ SOP_OpenVDB_Combine::cookMySop(OP_Context& context)
         evalString(bGroupStr, "groupB", 0, getTime());
 
         const auto* bGroup = (!bGdp ?
-            nullptr : matchGroup(const_cast<GU_Detail&>(*bGdp), bGroupStr.toStdString()));
+            nullptr : matchGroup(*bGdp, bGroupStr.toStdString()));
 
         // In Flatten A Groups mode, treat space-separated subpatterns
         // as specifying distinct groups to be processed independently.

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Convert.cc
@@ -1524,7 +1524,7 @@ SOP_OpenVDB_Convert::convertToPoly(
             evalString(maskStr, "adaptivityfieldname", 0, time);
 
             const GA_PrimitiveGroup *maskGroup =
-                matchGroup(const_cast<GU_Detail&>(*maskGeo), maskStr.toStdString());
+                matchGroup(*maskGeo, maskStr.toStdString());
 
             if (!maskGroup && maskStr.length() > 0) {
                 addWarning(SOP_MESSAGE, "Adaptivity field not found.");

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Create.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Create.cc
@@ -1003,7 +1003,7 @@ SOP_OpenVDB_Create::getReferenceVdb(OP_Context &context)
     UT_String refGroupStr;
     evalString(refGroupStr, "reference", 0, context.getTime());
     const GA_PrimitiveGroup* refGroup =
-        matchGroup(const_cast<GU_Detail&>(*refGdp), refGroupStr.toStdString());
+        matchGroup(*refGdp, refGroupStr.toStdString());
 
     hvdb::VdbPrimCIterator vdbIter(refGdp, refGroup);
     const GU_PrimVDB* refVdb = *vdbIter;

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Filter_Level_Set.cc
@@ -824,7 +824,7 @@ SOP_OpenVDB_Filter_Level_Set::cookMySop(OP_Context& context)
         evalString(groupStr, "group", 0, time);
 
         const GA_PrimitiveGroup *group =
-            matchGroup(const_cast<GU_Detail&>(*gdp), groupStr.toStdString());
+            matchGroup(*gdp, groupStr.toStdString());
         for (hvdb::VdbPrimIterator it(gdp, group); it; ++it) {
 
             // Check grid class

--- a/openvdb_houdini/houdini/SOP_OpenVDB_From_Particles.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_From_Particles.cc
@@ -847,7 +847,7 @@ SOP_OpenVDB_From_Particles::cookMySop(OP_Context& context)
             evalString(groupStr, "referencevdb", 0, mTime);
 
             const GA_PrimitiveGroup *group =
-                matchGroup(const_cast<GU_Detail&>(*refGeo), groupStr.toStdString());
+                matchGroup(*refGeo, groupStr.toStdString());
 
             hvdb::VdbPrimCIterator it(refGeo, group);
             const hvdb::GU_PrimVDB* refPrim = *it;

--- a/openvdb_houdini/houdini/SOP_OpenVDB_From_Polygons.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_From_Polygons.cc
@@ -779,7 +779,7 @@ SOP_OpenVDB_From_Polygons::cookMySop(OP_Context& context)
             UT_String groupStr;
             evalString(groupStr, "group", 0, time);
 
-            const GA_PrimitiveGroup *refGroup = matchGroup(const_cast<GU_Detail&>(*refGdp),
+            const GA_PrimitiveGroup *refGroup = matchGroup(*refGdp,
                 groupStr.toStdString());
 
             hvdb::VdbPrimCIterator gridIter(refGdp, refGroup);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Morph_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Morph_Level_Set.cc
@@ -467,7 +467,7 @@ SOP_OpenVDB_Morph_Level_Set::evalMorphingParms(OP_Context& context, MorphingParm
 
     evalString(str, "targetGroup", 0, now);
     const GA_PrimitiveGroup *targetGroup =
-        matchGroup(const_cast<GU_Detail&>(*targetGeo), str.toStdString());
+        matchGroup(*targetGeo, str.toStdString());
 
     hvdb::VdbPrimCIterator it(targetGeo, targetGroup);
     if (it) {
@@ -488,7 +488,7 @@ SOP_OpenVDB_Morph_Level_Set::evalMorphingParms(OP_Context& context, MorphingParm
     if (maskGeo) {
         evalString(str, "maskGroup", 0, now);
         const GA_PrimitiveGroup *maskGroup =
-            matchGroup(const_cast<GU_Detail&>(*maskGeo), str.toStdString());
+            matchGroup(*maskGeo, str.toStdString());
 
         hvdb::VdbPrimCIterator maskIt(maskGeo, maskGroup);
         if (maskIt) {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Noise.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Noise.cc
@@ -543,7 +543,7 @@ SOP_OpenVDB_Noise::cookMySop(OP_Context &context)
             evalString(groupStr, "maskGroup", 0, time);
 
             const GA_PrimitiveGroup* maskGroup =
-                matchGroup(const_cast<GU_Detail&>(*refGdp), groupStr.toStdString());
+                matchGroup(*refGdp, groupStr.toStdString());
 
             hvdb::VdbPrimCIterator gridIter(refGdp, maskGroup);
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Ray.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Ray.cc
@@ -432,7 +432,7 @@ SOP_OpenVDB_Ray::cookMySop(OP_Context& context)
         UT_String groupStr;
         evalString(groupStr, "group", 0, time);
         const GA_PrimitiveGroup* group =
-            matchGroup(const_cast<GU_Detail&>(*vdbGeo), groupStr.toStdString());
+            matchGroup(*vdbGeo, groupStr.toStdString());
         hvdb::VdbPrimCIterator vdbIt(vdbGeo, group);
 
         if (!vdbIt) {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Sample_Points.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Sample_Points.cc
@@ -344,7 +344,7 @@ SOP_OpenVDB_Sample_Points::sample(OP_Context& context)
     evalString(groupStr, "group", 0, time);
 
     const GA_PrimitiveGroup* group =
-        matchGroup(const_cast<GU_Detail&>(*bGdp), groupStr.toStdString());
+        matchGroup(*bGdp, groupStr.toStdString());
 
     // scratch variables used in the loop
     GA_Defaults defaultFloat(0.0), defaultInt(0);

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Scatter.cc
@@ -604,7 +604,7 @@ SOP_OpenVDB_Scatter::cookMySop(OP_Context& context)
         UT_String tmp;
         evalString(tmp, "group", 0, time);
         const GA_PrimitiveGroup* group
-            = this->matchGroup(const_cast<GU_Detail&>(*vdbgeo), tmp.toStdString());
+            = this->matchGroup(*vdbgeo, tmp.toStdString());
 
         evalString(tmp, "customname", 0, time);
         const std::string customName = tmp.toStdString();

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Segment.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Segment.cc
@@ -304,7 +304,7 @@ SOP_OpenVDB_Segment::cookMySop(OP_Context& context)
         {
             UT_String str;
             evalString(str, "group", 0, time);
-            group = matchGroup(const_cast<GU_Detail&>(*inputGeoPt), str.toStdString());
+            group = matchGroup(*inputGeoPt, str.toStdString());
         }
 
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_To_Polygons.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_To_Polygons.cc
@@ -715,7 +715,7 @@ SOP_OpenVDB_To_Polygons::cookMySop(OP_Context& context)
         UT_String groupStr;
         evalString(groupStr, "group", 0, time);
         const GA_PrimitiveGroup* group =
-            matchGroup(const_cast<GU_Detail&>(*vdbGeo), groupStr.toStdString());
+            matchGroup(*vdbGeo, groupStr.toStdString());
         hvdb::VdbPrimCIterator vdbIt(vdbGeo, group);
 
         if (!vdbIt) {
@@ -778,7 +778,7 @@ SOP_OpenVDB_To_Polygons::cookMySop(OP_Context& context)
                 evalString(maskStr, "adaptivityfieldname", 0, time);
 
                 const GA_PrimitiveGroup *maskGroup =
-                    matchGroup(const_cast<GU_Detail&>(*maskGeo), maskStr.toStdString());
+                    matchGroup(*maskGeo, maskStr.toStdString());
 
                 if (!maskGroup && maskStr.length() > 0) {
                     addWarning(SOP_MESSAGE, "Adaptivity field not found.");
@@ -934,7 +934,7 @@ SOP_OpenVDB_To_Polygons::referenceMeshing(
     // Check for reference VDB
     {
         const GA_PrimitiveGroup *refGroup =
-            matchGroup(const_cast<GU_Detail&>(*refGeo), "");
+            matchGroup(*refGeo, "");
         hvdb::VdbPrimCIterator refIt(refGeo, refGroup);
         if (refIt) {
             const openvdb::GridClass refClass = refIt->getGrid().getGridClass();

--- a/openvdb_houdini/houdini/SOP_OpenVDB_To_Spheres.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_To_Spheres.cc
@@ -265,7 +265,7 @@ SOP_OpenVDB_To_Spheres::cookMySop(OP_Context& context)
         UT_String groupStr;
         evalString(groupStr, "group", 0, time);
         const GA_PrimitiveGroup* group =
-            matchGroup(const_cast<GU_Detail&>(*vdbGeo), groupStr.toStdString());
+            matchGroup(*vdbGeo, groupStr.toStdString());
         hvdb::VdbPrimCIterator vdbIt(vdbGeo, group);
 
         if (!vdbIt) {

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Topology_To_Level_Set.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Topology_To_Level_Set.cc
@@ -294,8 +294,7 @@ SOP_OpenVDB_Topology_To_Level_Set::cookMySop(OP_Context& context)
 
         // Process VDB primitives
 
-        const GA_PrimitiveGroup* group =
-            matchGroup(const_cast<GU_Detail&>(*inputGeoPt), groupStr.toStdString());
+        const GA_PrimitiveGroup* group = matchGroup(*inputGeoPt, groupStr.toStdString());
 
         hvdb::VdbPrimCIterator vdbIt(inputGeoPt, group);
 


### PR DESCRIPTION
With detached groups, it is not necessary to have a non-const
GU_Detail to create ad-hoc groups, so there is no need to
cast away the const before invoking it.