### PR TITLE
The standard is unclear if std::isfinite works with int.

### DIFF
--- a/openvdb/math/Math.h
+++ b/openvdb/math/Math.h
@@ -344,7 +344,7 @@ template<> inline bool isNegative<bool>(const bool&) { return false; }
 /// Return @c true if @a x is finite.
 template<typename Type, typename std::enable_if<std::is_arithmetic<Type>::value, int>::type = 0>
 inline bool
-isFinite(const Type& x) { return std::isfinite(x); }
+isFinite(const Type& x) { return std::isfinite((double)x); }
 
 
 /// @brief Return @c true if @a a is equal to @a b to within

--- a/openvdb/math/Tuple.h
+++ b/openvdb/math/Tuple.h
@@ -179,7 +179,7 @@ public:
     /// True if no Nan or Inf values are present
     bool isFinite() const {
         for (int i = 0; i < SIZE; ++i) {
-            if (!std::isfinite(mm[i])) return false;
+            if (!std::isfinite((double)mm[i])) return false;
         }
         return true;
     }


### PR DESCRIPTION
MSVC templates this into fpclassify, which is then ambiguous with an int input.  I've worked around it by explicitly casting to (double), but making specializations of openvdb::math::isFinite() may also be an approach.