### PR TITLE
getUnload() does not return bool so cannot compare with true.

### DIFF
--- a/openvdb_houdini/houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.cc
@@ -398,8 +398,10 @@ SOP_NodeVDB::isSourceStealable(const unsigned index, OP_Context& context) const
         // if the SOP is a cache SOP we don't want to try and alter its data without a deep copy
         if (dynamic_cast<SOP_Cache*>(node))  return false;
 
-        if(node->getUnload() == true) return true;
-        else  return false;
+        if (node->getUnload())
+	    return true;
+        else
+	    return false;
     }
 #endif
     return false;

--- a/openvdb_houdini/houdini/SOP_NodeVDB.cc
+++ b/openvdb_houdini/houdini/SOP_NodeVDB.cc
@@ -398,7 +398,7 @@ SOP_NodeVDB::isSourceStealable(const unsigned index, OP_Context& context) const
         // if the SOP is a cache SOP we don't want to try and alter its data without a deep copy
         if (dynamic_cast<SOP_Cache*>(node))  return false;
 
-        if (node->getUnload())
+        if (node->getUnload() != 0)
 	    return true;
         else
 	    return false;


### PR DESCRIPTION
This generates an unsafe == warning on MSVC builds.