### PR TITLE
Improve Points Convert partial delete performance and add a toggle to selectively enable it

### DIFF
--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
@@ -277,6 +277,11 @@ newSopOperator(OP_OperatorTable* table)
         .setTooltip("The name of the VDB mask primitive to be created")
         .setDocumentation("The name of the VDB primitive to be created"));
 
+    parms.add(hutil::ParmFactory(PRM_TOGGLE, "keepnonvdbgeo", "Keep Non-VDB Geometry")
+        .setDefault(PRMoneDefaults)
+        .setTooltip("Enable to keep non-VDB geometry")
+        .setDocumentation("Enable to keep non-VDB geometry"));
+
     {   // Transform
         const char* items[] = {
             "targetpointspervoxel",  "Using Target Points Per Voxel",
@@ -558,6 +563,9 @@ SOP_OpenVDB_Points_Convert::updateParmsFlags()
     changed |= enableParm("maskname", useCustomName && toMask);
     changed |= setVisibleState("maskname", toMask);
 
+    changed |= enableParm("keepnonvdbgeo", !toVdbPoints);
+    changed |= setVisibleState("keepnonvdbgeo", !toVdbPoints);
+
     const int refexists = (this->nInputs() == 2);
 
     changed |= enableParm("transform", toVdbPoints);
@@ -620,6 +628,7 @@ SOP_OpenVDB_Points_Convert::cookMySop(OP_Context& context)
         const fpreal time = context.getTime();
 
         const int conversion = static_cast<int>(evalInt("conversion", 0, time));
+        const bool keepNonVDBGeo = evalInt("keepnonvdbgeo", 0, time) == 1;
 
         UT_String groupStr;
         evalString(groupStr, "group", 0, time);
@@ -639,28 +648,88 @@ SOP_OpenVDB_Points_Convert::cookMySop(OP_Context& context)
                 includeGroups, excludeGroups, pointsGroup);
         }
 
-        if (conversion == MODE_CONVERT_FROM_VDB) {
+        // Optionally copy transform parameters from reference grid (if not converting from VDB).
 
-            // Duplicate primary (left) input geometry and convert the VDB points inside
+        Transform::Ptr transform;
 
-            if (duplicateSourceStealable(0, context) >= UT_ERROR_ABORT) return error();
+        if (conversion != MODE_CONVERT_FROM_VDB) {
+            if (const GU_Detail* refGeo = inputGeo(1, context)) {
 
-            // passing an empty vector of attribute names implies that
-            // all attributes should be converted
-            const std::vector<std::string> emptyNameVector;
+                UT_String refvdbStr;
+                evalString(refvdbStr, "refvdb", 0, time);
+
+                const GA_PrimitiveGroup *group = matchGroup(*refGeo, refvdbStr.toStdString());
+
+                hvdb::VdbPrimCIterator it(refGeo, group);
+                const hvdb::GU_PrimVDB* refPrim = *it;
+
+                if (!refPrim) {
+                    addError(SOP_MESSAGE, "Second input has no VDB primitives.");
+                    return error();
+                }
+
+                transform = refPrim->getGrid().transform().copy();
+            }
+        }
+
+        // handle to VDB, count and mask conversion options
+
+        if (conversion != MODE_CONVERT_TO_VDB) {
 
             UT_Array<GEO_Primitive*> primsToDelete;
             primsToDelete.clear();
 
-            // Convert each VDB primitive independently
-            for (hvdb::VdbPrimIterator vdbIt(gdp, group); vdbIt; ++vdbIt) {
+            if (keepNonVDBGeo) {
+                // Duplicate primary (left) input geometry
 
-                GU_Detail geo;
+                if (duplicateSourceStealable(0, context) >= UT_ERROR_ABORT) return error();
 
-                const GridBase& baseGrid = vdbIt->getGrid();
-                if (!baseGrid.isType<PointDataGrid>()) continue;
+                // Extract VDB primitives to delete
 
-                const PointDataGrid& grid = static_cast<const PointDataGrid&>(baseGrid);
+                for (hvdb::VdbPrimIterator vdbIt(gdp, group); vdbIt; ++vdbIt) {
+                    openvdb::GridBase::ConstPtr gridBase = vdbIt->getConstGridPtr();
+                    PointDataGrid::ConstPtr points =
+                        openvdb::GridBase::constGrid<PointDataGrid>(gridBase);
+                    if (!points)    continue;
+
+                    primsToDelete.append(*vdbIt);
+                }
+            }
+            else {
+                gdp->clearAndDestroy();
+            }
+
+            // Extract point grids and names for conversion
+
+            std::vector<PointDataGrid::ConstPtr> pointGrids;
+            std::vector<std::string> pointNames;
+
+            const GU_Detail* sourceGdp = keepNonVDBGeo ? gdp : inputGeo(0, context);
+
+            for (hvdb::VdbPrimCIterator vdbIt(sourceGdp, group); vdbIt; ++vdbIt) {
+                openvdb::GridBase::ConstPtr gridBase = vdbIt->getConstGridPtr();
+                PointDataGrid::ConstPtr points =
+                    openvdb::GridBase::constGrid<PointDataGrid>(gridBase);
+                if (!points)    continue;
+
+                pointGrids.push_back(points);
+
+                if (conversion != MODE_CONVERT_FROM_VDB) {
+                    const std::string gridName = vdbIt.getPrimitiveName().toStdString();
+
+                    pointNames.push_back(gridName);
+                }
+            }
+
+            if (keepNonVDBGeo) {
+                gdp->deletePrimitives(primsToDelete, true);
+            }
+
+            if (conversion == MODE_CONVERT_FROM_VDB) {
+
+                // passing an empty vector of attribute names implies that
+                // all attributes should be converted
+                const std::vector<std::string> emptyNameVector;
 
                 // if all point data is being converted, sequentially pre-fetch any out-of-core
                 // data for faster performance when using delayed-loading
@@ -669,30 +738,98 @@ SOP_OpenVDB_Points_Convert::cookMySop(OP_Context& context)
                                         includeGroups.empty() &&
                                         excludeGroups.empty();
 
-                if (allData) {
-                    prefetch(grid.tree());
+                for (PointDataGrid::ConstPtr grid : pointGrids) {
+
+                    GU_Detail geo;
+
+                    // if all the data is being loaded, prefetch it for faster load performance
+
+                    if (allData) {
+                        prefetch(grid->tree());
+                    }
+
+                    // perform conversion
+
+                    hvdb::convertPointDataGridToHoudini(
+                        geo, *grid, emptyNameVector, includeGroups, excludeGroups);
+
+                    const MetaMap& metaMap = *grid;
+                    std::vector<std::string> warnings;
+                    hvdb::convertMetadataToHoudini(geo, metaMap, warnings);
+                    if (warnings.size() > 0) {
+                        for (const auto& warning: warnings) {
+                            addWarning(SOP_MESSAGE, warning.c_str());
+                        }
+                    }
+
+                    gdp->merge(geo);
                 }
 
-                // perform conversion
+                return error();
+            }
+            else {
 
-                hvdb::convertPointDataGridToHoudini(
-                    geo, grid, emptyNameVector, includeGroups, excludeGroups);
+                const auto outputName = getOutputNameMode(time);
 
-                const MetaMap& metaMap = grid;
-                std::vector<std::string> warnings;
-                hvdb::convertMetadataToHoudini(geo, metaMap, warnings);
-                if (warnings.size() > 0) {
-                    for (const auto& warning: warnings) {
-                        addWarning(SOP_MESSAGE, warning.c_str());
+                int i = 0;
+
+                for (PointDataGrid::ConstPtr grid : pointGrids) {
+
+                    assert(i < pointNames.size());
+                    const std::string gridName = pointNames[i++];
+
+                    GU_Detail geo;
+
+                    if (conversion == MODE_GENERATE_MASK) {
+                        openvdb::BoolGrid::Ptr maskGrid;
+                        if (transform) {
+                            maskGrid = openvdb::points::convertPointsToMask(
+                                *grid, *transform, includeGroups, excludeGroups);
+                        }
+                        else {
+                            maskGrid = openvdb::points::convertPointsToMask(
+                                *grid, includeGroups, excludeGroups);
+                        }
+
+                        UT_String nameStr = "";
+                        evalString(nameStr, "maskname", 0, time);
+                        std::string customName = nameStr.toStdString();
+
+                        std::string vdbName;
+                        switch (outputName) {
+                            case NAME_KEEP:    vdbName = gridName; break;
+                            case NAME_APPEND:  vdbName = gridName + customName; break;
+                            case NAME_REPLACE: vdbName = customName; break;
+                        }
+                        hvdb::createVdbPrimitive(*gdp, maskGrid, vdbName.c_str());
+                    }
+                    else {
+                        openvdb::Int32Grid::Ptr countGrid;
+                        if (transform) {
+                            countGrid = openvdb::points::pointCountGrid(
+                                *grid, *transform, includeGroups, excludeGroups);
+                        }
+                        else {
+                            countGrid = openvdb::points::pointCountGrid(
+                                *grid, includeGroups, excludeGroups);
+                        }
+
+                        UT_String nameStr = "";
+                        evalString(nameStr, "countname", 0, time);
+                        std::string customName = nameStr.toStdString();
+
+                        std::string vdbName;
+                        switch (outputName) {
+                            case NAME_KEEP:    vdbName = gridName; break;
+                            case NAME_APPEND:  vdbName = gridName + customName; break;
+                            case NAME_REPLACE: vdbName = customName; break;
+                        }
+                        hvdb::createVdbPrimitive(*gdp, countGrid, vdbName.c_str());
                     }
                 }
 
-                gdp->merge(geo);
-                primsToDelete.append(*vdbIt);
+                return error();
             }
-
-            gdp->deletePrimitives(primsToDelete, true);
-            return error();
         }
 
         // if we're here, we're converting Houdini points to OpenVDB. Clear gdp entirely
@@ -701,97 +838,6 @@ SOP_OpenVDB_Points_Convert::cookMySop(OP_Context& context)
         gdp->clearAndDestroy();
 
         const GU_Detail* ptGeo = inputGeo(0, context);
-
-        // Set member data
-
-        Transform::Ptr transform;
-
-        // Optionally copy transform parameters from reference grid.
-
-        if (const GU_Detail* refGeo = inputGeo(1, context)) {
-
-            UT_String refvdbStr;
-            evalString(refvdbStr, "refvdb", 0, time);
-
-            const GA_PrimitiveGroup *group = matchGroup(*refGeo, refvdbStr.toStdString());
-
-            hvdb::VdbPrimCIterator it(refGeo, group);
-            const hvdb::GU_PrimVDB* refPrim = *it;
-
-            if (!refPrim) {
-                addError(SOP_MESSAGE, "Second input has no VDB primitives.");
-                return error();
-            }
-
-            transform = refPrim->getGrid().transform().copy();
-        }
-
-        if (conversion == MODE_GENERATE_MASK || conversion == MODE_COUNT_POINTS) {
-
-            const auto outputName = getOutputNameMode(time);
-
-            // Process each VDB primitive independently
-            for (hvdb::VdbPrimCIterator vdbIt(ptGeo, group); vdbIt; ++vdbIt) {
-
-                const std::string gridName = vdbIt.getPrimitiveName().toStdString();
-
-                GU_Detail geo;
-
-                const GridBase& baseGrid = vdbIt->getGrid();
-                if (!baseGrid.isType<PointDataGrid>()) continue;
-
-                const PointDataGrid& grid = static_cast<const PointDataGrid&>(baseGrid);
-
-                if (conversion == MODE_GENERATE_MASK) {
-                    openvdb::BoolGrid::Ptr maskGrid;
-                    if (transform) {
-                        maskGrid = openvdb::points::convertPointsToMask(
-                            grid, *transform, includeGroups, excludeGroups);
-                    }
-                    else {
-                        maskGrid = openvdb::points::convertPointsToMask(
-                            grid, includeGroups, excludeGroups);
-                    }
-
-                    UT_String nameStr = "";
-                    evalString(nameStr, "maskname", 0, time);
-                    std::string customName = nameStr.toStdString();
-
-                    std::string vdbName;
-                    switch (outputName) {
-                        case NAME_KEEP:    vdbName = gridName; break;
-                        case NAME_APPEND:  vdbName = gridName + customName; break;
-                        case NAME_REPLACE: vdbName = customName; break;
-                    }
-                    hvdb::createVdbPrimitive(*gdp, maskGrid, vdbName.c_str());
-                }
-                else {
-                    openvdb::Int32Grid::Ptr countGrid;
-                    if (transform) {
-                        countGrid = openvdb::points::pointCountGrid(
-                            grid, *transform, includeGroups, excludeGroups);
-                    }
-                    else {
-                        countGrid = openvdb::points::pointCountGrid(
-                            grid, includeGroups, excludeGroups);
-                    }
-
-                    UT_String nameStr = "";
-                    evalString(nameStr, "countname", 0, time);
-                    std::string customName = nameStr.toStdString();
-
-                    std::string vdbName;
-                    switch (outputName) {
-                        case NAME_KEEP:    vdbName = gridName; break;
-                        case NAME_APPEND:  vdbName = gridName + customName; break;
-                        case NAME_REPLACE: vdbName = customName; break;
-                    }
-                    hvdb::createVdbPrimitive(*gdp, countGrid, vdbName.c_str());
-                }
-            }
-
-            return error();
-        }
 
         const auto transformMode = evalInt("transform", 0, time);
 


### PR DESCRIPTION
* Resolve performance issues in partial delete by deleting all VDB primitives from the gdp first
* Add partial delete functionality to mask and count modes
* New toggle enabled for unpack, count and mask modes to selectively retain non-VDB geometry