### PR TITLE
Fix Travis CI error reporting

### DIFF
--- a/travis/travis.run
+++ b/travis/travis.run
@@ -43,7 +43,7 @@
 #
 # Author: Dan Bailey
 
-set -x
+set -ex
 
 TASK="$1"
 ABI="$2"


### PR DESCRIPTION
After adding ccache stats to the final step of the Travis builds, bash was not correctly erroring on the first error, meaning errors typically aren't being reported correctly.