### PR TITLE
Add Houdini 16.5 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,8 @@ env:
   - ABI=4 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=none
 
-  # Build Houdini plug-ins for H15.0, H15.5, H16.0
+  # Build Houdini plug-ins for H15.0, H15.5, H16.0, H16.5
+  - ABI=4 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=16.5
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=16.0
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=15.5
   - ABI=3 BLOSC=yes RELEASE=yes HOUDINI_MAJOR=15.0

--- a/travis/travis.run
+++ b/travis/travis.run
@@ -37,7 +37,7 @@
 # ABI (3/4/5) - the ABI version of OpenVDB
 # BLOSC (yes/no) - to build with Blosc support
 # RELEASE (yes/no) - to build in release or debug mode
-# HOUDINI_MAJOR (15.0/15.5/16.0) - the major version of Houdini
+# HOUDINI_MAJOR (15.0/15.5/16.0/16.5) - the major version of Houdini
 #
 # (Note Travis instances allow only 7.5GB of memory per VM, so limit concurrent builds to 4)
 #
@@ -78,6 +78,8 @@ HOUDINI_BLOSC_ARGS="    BLOSC_INCL_DIR=/test/hou/toolkit/include\
                         BLOSC_LIB_DIR=/test/hou/dsolib"
 NO_BLOSC_ARGS="         BLOSC_INCL_DIR=\
                         BLOSC_LIB_DIR="
+
+HOUDINI_HAS_BOOST=$(echo "$HOUDINI_MAJOR < 16.5" | bc -l)
 
 # introduce wrapper to clang++ that uses ccache, this is mainly
 # for use in hcustom where changing the compiler is hard
@@ -124,6 +126,13 @@ if [ "$TASK" = "install" ]; then
         cd hou
         tar -xzf houdini.tar.gz
         cd -
+        # boost no longer shipped with Houdini from 16.5 onwards
+        if [ $HOUDINI_HAS_BOOST -eq 0 ]; then
+            sudo apt-get install -y libboost-all-dev
+            cp -r /usr/include/boost /test/hou/toolkit/include
+            cp /usr/lib/x86_64-linux-gnu/libboost_iostreams.so* /test/hou/dsolib
+            cp /usr/lib/x86_64-linux-gnu/libboost_system.so* /test/hou/dsolib
+        fi
     fi
 elif [ "$TASK" = "script" ]; then
     if [ "$HOUDINI_MAJOR" = "none" ]; then


### PR DESCRIPTION
Extend Travis CI to build the latest production build for Houdini 16.5. This change also handles the fact that Houdini 16.5 no longer ships with Boost.