### PR TITLE
Update FindOpenVDB.cmake

### DIFF
--- a/cmake/FindOpenVDB.cmake
+++ b/cmake/FindOpenVDB.cmake
@@ -46,7 +46,7 @@
 FIND_PACKAGE( PackageHandleStandardArgs )
 
 FIND_PATH( OPENVDB_LOCATION include/openvdb/version.h 
-  "ENV{OPENVDB_ROOT}"
+  "$ENV{OPENVDB_ROOT}"
   NO_DEFAULT_PATH
   NO_SYSTEM_ENVIRONMENT_PATH
   )


### PR DESCRIPTION
Missing '$' infront of the environment. This is needed to correctly locate the built openvVDB library once compiled and linked in an external project.