### PR TITLE
VDB Points Advection

### DIFF
--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -357,6 +357,7 @@ INCLUDE_NAMES := \
     points/AttributeSet.h \
     points/IndexFilter.h \
     points/IndexIterator.h \
+    points/PointAdvect.h \
     points/PointAttribute.h \
     points/PointConversion.h \
     points/PointCount.h \
@@ -525,6 +526,7 @@ UNITTEST_SRC_NAMES := \
     unittest/TestNodeMask.cc \
     unittest/TestParticleAtlas.cc \
     unittest/TestParticlesToLevelSet.cc \
+    unittest/TestPointAdvect.cc \
     unittest/TestPointAttribute.cc \
     unittest/TestPointConversion.cc \
     unittest/TestPointCount.cc \

--- a/openvdb/Makefile
+++ b/openvdb/Makefile
@@ -364,6 +364,7 @@ INCLUDE_NAMES := \
     points/PointDelete.h \
     points/PointGroup.h \
     points/PointMask.h \
+    points/PointMove.h \
     points/PointScatter.h \
     points/StreamCompression.h \
     tools/ChangeBackground.h \
@@ -532,6 +533,7 @@ UNITTEST_SRC_NAMES := \
     unittest/TestPointGroup.cc \
     unittest/TestPointIndexGrid.cc \
     unittest/TestPointMask.cc \
+    unittest/TestPointMove.cc \
     unittest/TestPointPartitioner.cc \
     unittest/TestPointScatter.cc \
     unittest/TestPointsToMask.cc \

--- a/openvdb/doc/examplecode.txt
+++ b/openvdb/doc/examplecode.txt
@@ -45,7 +45,9 @@ illustrate how to use OpenVDB and how to perform common tasks.
   - @ref sPointCustomFiltering
 - @ref sPointStride
   - @ref sConstantStride
-
+- @ref sPointMove
+  - @ref sPointAdvect
+  - @ref sPointCustomDeformer
 
 @section sHelloWorld &ldquo;Hello, World&rdquo; for OpenVDB
 This is a very simple example showing how to create a grid and access
@@ -1551,8 +1553,6 @@ Leaf[0, 0, 0]
 This example demonstrates how to create a new point grid and to populate it with
 random point positions initialized inside a level set sphere.
 
-Note that multi-threaded scattering tools are currently in development for
-introduction to the library to handle this use-case.
 @code
 #include <iostream>
 #include <openvdb/openvdb.h>
@@ -2058,6 +2058,59 @@ for (auto leafIter = points->tree().beginLeaf(); leafIter; ++leafIter) {
         }
     }
 }
+@endcode
+
+@section sPointMove Moving Points in Space
+
+As points are stored within voxels in an implicit spatially organised data structure, moving points in space requires re-sorting the data.
+
+@subsection sPointAdvect Advecting Points
+
+Advection uses a specified integration order (4 = runge-kutta 4th) as well as delta time and time-step parameters
+to advect the points in-place using the supplied velocity grid.
+
+@code
+// Create an empty velocity grid with gravity as background value
+auto gravity = openvdb::Vec3SGrid::create(openvdb::Vec3s(0, -9.81, 0));
+
+// Advect points in-place using gravity velocity grid
+openvdb::points::advectPoints(*points, *gravity,
+    /*integrationOrder=*/4, /*dt=*/1.0/24.0, /*timeSteps=*/1);
+@endcode
+
+@subsection sPointCustomDeformer Moving Points with a Custom Deformer
+
+A custom deformer generates the new position of each existing point in a point set. This can use any number of
+mechanisms to achieve this such as a static value, a hard-coded list of positions, a function that uses the
+existing position to compute the new one or a function that uses the index of the point within the leaf array in
+some other way. This example simply takes the input position and adds a Y offset. Note that it is also possible
+to configure a custom deformer to operate in index-space.
+
+@code
+// This custom deformer is also used in the TestPointMove unit tests.
+struct OffsetDeformer
+{
+    OffsetDeformer(const openvdb::Vec3d& _offset)
+        : offset(_offset){ }
+
+    template <typename LeafIterT>
+    void reset(const LeafIterT&) { }
+
+    template <typename IndexIterT>
+    void apply(openvdb::Vec3d& position, const IndexIterT&) const
+    {
+        position += offset;
+    }
+
+    openvdb::Vec3d offset;
+};
+
+// Create an OffsetDeformer that moves the points downwards in Y by 10 world-space units.
+openvdb::Vec3d offset(0, -10, 0);
+OffsetDeformer deformer(offset);
+
+// Move the points using this deformer
+openvdb::points::movePoints(*points, deformer);
 @endcode
 
 */

--- a/openvdb/doc/examplecode.txt
+++ b/openvdb/doc/examplecode.txt
@@ -2062,7 +2062,7 @@ for (auto leafIter = points->tree().beginLeaf(); leafIter; ++leafIter) {
 
 @section sPointMove Moving Points in Space
 
-As points are stored within voxels in an implicit spatially organised data structure, moving points in space requires re-sorting the data.
+As points are stored within voxels in an implicit spatially organised data structure, moving points in space requires re-bucketing the data.
 
 @subsection sPointAdvect Advecting Points
 

--- a/openvdb/points/AttributeArray.h
+++ b/openvdb/points/AttributeArray.h
@@ -671,6 +671,8 @@ public:
 
     ValueType get(Index n, Index m = 0) const;
 
+    const AttributeArray& array() const;
+
 protected:
     Index index(Index n, Index m) const;
 
@@ -740,6 +742,8 @@ public:
 
     void set(Index n, const ValueType& value);
     void set(Index n, Index m, const ValueType& value);
+
+    AttributeArray& array();
 
 private:
     friend class ::TestAttributeArray;
@@ -1934,6 +1938,13 @@ AttributeHandle<ValueType, CodecType>::compatibleType() const
 }
 
 template <typename ValueType, typename CodecType>
+const AttributeArray& AttributeHandle<ValueType, CodecType>::array() const
+{
+    assert(mArray);
+    return *mArray;
+}
+
+template <typename ValueType, typename CodecType>
 Index AttributeHandle<ValueType, CodecType>::index(Index n, Index m) const
 {
     Index index = n * mStrideOrTotalSize + m;
@@ -2058,6 +2069,13 @@ AttributeWriteHandle<ValueType, CodecType>::set(Index index, const ValueType& va
     // if the codec is known, call the method on the attribute array directly
 
     TypedAttributeArray<ValueType, CodecType>::setUnsafe(const_cast<AttributeArray*>(this->mArray), index, value);
+}
+
+template <typename ValueType, typename CodecType>
+AttributeArray& AttributeWriteHandle<ValueType, CodecType>::array()
+{
+    assert(this->mArray);
+    return *const_cast<AttributeArray*>(this->mArray);
 }
 
 

--- a/openvdb/points/PointAdvect.h
+++ b/openvdb/points/PointAdvect.h
@@ -1,0 +1,276 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2012-2018 DreamWorks Animation LLC
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+//
+/// @author Dan Bailey
+///
+/// @file PointAdvect.h
+///
+/// @brief Ability to advect VDB Points through a velocity field.
+///
+
+#ifndef OPENVDB_POINTS_POINT_ADVECT_HAS_BEEN_INCLUDED
+#define OPENVDB_POINTS_POINT_ADVECT_HAS_BEEN_INCLUDED
+
+#include <openvdb/openvdb.h>
+#include <openvdb/tools/Prune.h>
+#include <openvdb/tools/VelocityFields.h>
+
+#include <openvdb/points/AttributeGroup.h>
+#include <openvdb/points/PointDataGrid.h>
+#include <openvdb/points/PointGroup.h>
+#include <openvdb/points/PointMove.h>
+
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+
+/// @brief Advect points in a PointDataGrid through a velocity grid
+/// @param points               the PointDataGrid containing the points to be advected.
+/// @param velocity             a velocity grid to be sampled.
+/// @param integrationOrder     the integration scheme to use (1 is forward euler, 4 is runge-kutta 4th)
+/// @param dt                   delta time.
+/// @param timeSteps            number of advection steps to perform.
+/// @param advectFilter         an optional advection index filter (moves a subset of the points)
+/// @param filter               an optional index filter (deletes a subset of the points)
+/// @param cached               caches velocity interpolation for faster performance, disable to use
+///                             less memory (default is on).
+template <typename PointDataGridT, typename VelGridT,
+    typename AdvectFilterT = NullFilter, typename FilterT = NullFilter>
+inline void advectPoints(PointDataGridT& points, const VelGridT& velocity,
+                         const Index integrationOrder, const double dt, const Index timeSteps,
+                         const AdvectFilterT& advectFilter = NullFilter(),
+                         const FilterT& filter = NullFilter(),
+                         const bool cached = true);
+
+
+////////////////////////////////////////
+
+
+namespace point_advect_internal {
+
+enum IntegrationOrder {
+    INTEGRATION_ORDER_FWD_EULER = 1,
+    INTEGRATION_ORDER_RK_2ND,
+    INTEGRATION_ORDER_RK_3RD,
+    INTEGRATION_ORDER_RK_4TH
+};
+
+template <typename VelGridT, Index IntegrationOrder, bool Staggered, typename FilterT>
+class AdvectionDeformer
+{
+public:
+    using IntegratorT = openvdb::tools::VelocityIntegrator<VelGridT, Staggered>;
+
+    AdvectionDeformer(const VelGridT& velocityGrid, const double timeStep, const int steps,
+                      const FilterT& filter)
+        : mIntegrator(velocityGrid)
+        , mTimeStep(timeStep)
+        , mSteps(steps)
+        , mFilter(filter) { }
+
+    template <typename LeafT>
+    void reset(const LeafT& leaf, size_t /*idx*/)
+    {
+        mFilter.reset(leaf);
+    }
+
+    template <typename IndexIterT>
+    void apply(Vec3d& position, const IndexIterT& iter) const
+    {
+        if (mFilter.valid(iter)) {
+            for (int n = 0; n < mSteps; ++n) {
+                mIntegrator.template rungeKutta<IntegrationOrder, openvdb::Vec3d>(mTimeStep, position);
+            }
+        }
+    }
+
+private:
+    IntegratorT mIntegrator;
+    double mTimeStep;
+    const int mSteps;
+    FilterT mFilter;
+}; // class AdvectionDeformer
+
+
+template <typename PointDataGridT, typename VelGridT, typename AdvectFilterT, typename FilterT>
+struct AdvectionOp
+{
+    using CachedDeformerT = CachedDeformer<double>;
+
+    AdvectionOp(PointDataGridT& points, const VelGridT& velocity,
+                const Index integrationOrder, const double timeStep, const Index steps,
+                const AdvectFilterT& advectFilter,
+                const FilterT& filter)
+        : mPoints(points)
+        , mVelocity(velocity)
+        , mIntegrationOrder(integrationOrder)
+        , mTimeStep(timeStep)
+        , mSteps(steps)
+        , mAdvectFilter(advectFilter)
+        , mFilter(filter) { }
+
+    void cache()
+    {
+        mCachedDeformer.reset(new CachedDeformerT(mCache));
+        (*this)(true);
+    }
+
+    void advect()
+    {
+        (*this)(false);
+    }
+
+private:
+    template <int IntegrationOrder, bool Staggered>
+    void resolveIntegrationOrder(bool buildCache)
+    {
+        const auto leaf = mPoints.constTree().cbeginLeaf();
+        if (!leaf)  return;
+
+        // move points according to the pre-computed cache
+        if (!buildCache && mCachedDeformer) {
+            movePoints(mPoints, *mCachedDeformer, mFilter);
+            return;
+        }
+
+        NullFilter nullFilter;
+
+        if (buildCache) {
+            // disable group filtering from the advection deformer and perform group filtering
+            // in the cache deformer instead, this restricts the cache to just containing
+            // positions from points which are both deforming *and* are not being deleted
+            AdvectionDeformer<VelGridT, IntegrationOrder, Staggered, NullFilter> deformer(
+                mVelocity, mTimeStep, mSteps, nullFilter);
+            if (mFilter.state() == index::ALL && mAdvectFilter.state() == index::ALL) {
+                mCachedDeformer->evaluate(mPoints, deformer, nullFilter);
+            } else {
+                BinaryFilter<AdvectFilterT, FilterT, /*And=*/true> binaryFilter(
+                    mAdvectFilter, mFilter);
+                mCachedDeformer->evaluate(mPoints, deformer, binaryFilter);
+            }
+        }
+        else {
+            // revert to NullFilter if all points are being evaluated
+            if (mAdvectFilter.state() == index::ALL) {
+                AdvectionDeformer<VelGridT, IntegrationOrder, Staggered, NullFilter> deformer(
+                    mVelocity, mTimeStep, mSteps, nullFilter);
+                movePoints(mPoints, deformer, mFilter);
+            }
+            else {
+                AdvectionDeformer<VelGridT, IntegrationOrder, Staggered, AdvectFilterT> deformer(
+                    mVelocity, mTimeStep, mSteps, mAdvectFilter);
+                movePoints(mPoints, deformer, mFilter);
+            }
+        }
+    }
+
+    template <bool Staggered>
+    void resolveStaggered(bool buildCache)
+    {
+        if (mIntegrationOrder == INTEGRATION_ORDER_FWD_EULER) {
+            resolveIntegrationOrder<1, Staggered>(buildCache);
+        } else if (mIntegrationOrder == INTEGRATION_ORDER_RK_2ND) {
+            resolveIntegrationOrder<2, Staggered>(buildCache);
+        } else if (mIntegrationOrder == INTEGRATION_ORDER_RK_3RD) {
+            resolveIntegrationOrder<3, Staggered>(buildCache);
+        } else if (mIntegrationOrder == INTEGRATION_ORDER_RK_4TH) {
+            resolveIntegrationOrder<4, Staggered>(buildCache);
+        }
+    }
+
+    void operator()(bool buildCache)
+    {
+        // early-exit if no leafs
+        if (mPoints.constTree().leafCount() == 0)            return;
+
+        if (mVelocity.getGridClass() == openvdb::GRID_STAGGERED) {
+            resolveStaggered<true>(buildCache);
+        } else {
+            resolveStaggered<false>(buildCache);
+        }
+    }
+
+    PointDataGridT& mPoints;
+    const VelGridT& mVelocity;
+    const Index mIntegrationOrder;
+    const double mTimeStep;
+    const Index mSteps;
+    const AdvectFilterT& mAdvectFilter;
+    const FilterT& mFilter;
+    CachedDeformerT::Cache mCache;
+    std::unique_ptr<CachedDeformerT> mCachedDeformer;
+}; // struct AdvectionOp
+
+} // namespace point_advect_internal
+
+
+////////////////////////////////////////
+
+
+template <typename PointDataGridT, typename VelGridT, typename AdvectFilterT, typename FilterT>
+inline void advectPoints(PointDataGridT& points, const VelGridT& velocity,
+                         const Index integrationOrder, const double timeStep, const Index steps,
+                         const AdvectFilterT& advectFilter,
+                         const FilterT& filter,
+                         const bool cached)
+{
+    using namespace point_advect_internal;
+
+    if (steps == 0)     return;
+
+    if (integrationOrder > 4) {
+        throw ValueError{"Unknown integration order for advecting points."};
+    }
+
+    AdvectionOp<PointDataGridT, VelGridT, AdvectFilterT, FilterT> op(
+        points, velocity, integrationOrder, timeStep, steps,
+        advectFilter, filter);
+
+    // if caching is enabled, sample the velocity field using a CachedDeformer to store the
+    // intermediate positions before moving the points, this uses more memory but typically
+    // results in faster overall performance
+    if (cached)     op.cache();
+
+    // advect the points
+    op.advect();
+}
+
+} // namespace points
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif // OPENVDB_POINTS_POINT_ADVECT_HAS_BEEN_INCLUDED
+
+// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/points/PointCount.h
+++ b/openvdb/points/PointCount.h
@@ -194,8 +194,13 @@ pointCountGrid( const PointDataGridT& points,
     static_assert(  std::is_integral<typename GridT::ValueType>::value ||
                     std::is_floating_point<typename GridT::ValueType>::value,
         "openvdb::points::pointCountGrid must return an integer or floating-point scalar grid");
-    return point_mask_internal::convertPointsToScalar<PointDataGridT, GridT>(
-        points, filter);
+
+    // This is safe because the PointDataGrid can only be modified by the deformer
+    using AdapterT = TreeAdapter<typename PointDataGridT::TreeType>;
+    auto& nonConstPoints = const_cast<typename AdapterT::NonConstGridType&>(points);
+
+    return point_mask_internal::convertPointsToScalar<GridT>(
+        nonConstPoints, filter);
 }
 
 
@@ -208,8 +213,14 @@ pointCountGrid( const PointDataGridT& points,
     static_assert(  std::is_integral<typename GridT::ValueType>::value ||
                     std::is_floating_point<typename GridT::ValueType>::value,
         "openvdb::points::pointCountGrid must return an integer or floating-point scalar grid");
-    return point_mask_internal::convertPointsToScalar<PointDataGridT, GridT>(
-        points, transform, filter);
+
+    // This is safe because the PointDataGrid can only be modified by the deformer
+    using AdapterT = TreeAdapter<typename PointDataGridT::TreeType>;
+    auto& nonConstPoints = const_cast<typename AdapterT::NonConstGridType&>(points);
+
+    NullDeformer deformer;
+    return point_mask_internal::convertPointsToScalar<GridT>(
+        nonConstPoints, transform, filter, deformer);
 }
 
 

--- a/openvdb/points/PointMask.h
+++ b/openvdb/points/PointMask.h
@@ -223,8 +223,8 @@ struct PointsToTransformedScalarOp
         : mTargetTransform(targetTransform)
         , mSourceTransform(sourceTransform)
         , mFilter(filter)
-        , mCombinable(combinable)
-        , mDeformer(deformer) { }
+        , mDeformer(deformer)
+        , mCombinable(combinable) { }
 
     void operator()(const PointDataLeafT& leaf, size_t idx) const
     {

--- a/openvdb/points/PointMask.h
+++ b/openvdb/points/PointMask.h
@@ -87,10 +87,46 @@ convertPointsToMask(const PointDataGridT& grid,
                     bool threaded = true);
 
 
+/// @brief No-op deformer (adheres to the deformer interface documented in PointMove.h)
+struct NullDeformer
+{
+    template <typename LeafT>
+    void reset(LeafT& leaf, size_t idx = 0) { }
+
+    template <typename IterT>
+    void apply(Vec3d&, IterT&) const { }
+};
+
+/// @brief Deformer Traits for optionally configuring deformers to be applied
+/// in index-space. The default is world-space.
+template <typename DeformerT>
+struct DeformerTraits
+{
+    static const bool IndexSpace = false;
+};
+
+
 ////////////////////////////////////////
 
 
 namespace point_mask_internal {
+
+template <typename LeafT>
+void voxelSum(LeafT& leaf, const Index offset, const typename LeafT::ValueType& value)
+{
+    leaf.modifyValue(offset, tools::valxform::SumOp<typename LeafT::ValueType>(value));
+}
+
+// overload PointDataLeaf access to use setOffsetOn(), as modifyValue()
+// is intentionally disabled to avoid accidental usage
+
+template <typename T, Index Log2Dim>
+void voxelSum(PointDataLeafNode<T, Log2Dim>& leaf, const Index offset,
+    const typename PointDataLeafNode<T, Log2Dim>::ValueType& value)
+{
+    leaf.setOffsetOn(offset, leaf.getValue(offset) + value);
+}
+
 
 /// @brief Combines multiple grids into one by stealing leaf nodes and summing voxel values
 /// This class is designed to work with thread local storage containers such as tbb::combinable
@@ -120,7 +156,7 @@ struct GridCombinerOp
             else {
                 // otherwise increment existing values
                 for (auto iter = leaf->cbeginValueOn(); iter; ++iter) {
-                    newLeaf->modifyValue(iter.getCoord(), SumOp(*iter));
+                    voxelSum(*newLeaf, iter.offset(), ValueType(*iter));
                 }
             }
         }
@@ -138,7 +174,7 @@ struct PointsToScalarOp
     using LeafT = typename GridT::TreeType::LeafNodeType;
     using ValueT = typename LeafT::ValueType;
 
-    PointsToScalarOp(   const PointDataGridT& grid,
+    PointsToScalarOp(   PointDataGridT& grid,
                         const FilterT& filter)
         : mPointDataAccessor(grid.getConstAccessor())
         , mFilter(filter) { }
@@ -171,7 +207,7 @@ private:
 
 /// @brief Compute scalar grid from PointDataGrid using a different transform
 ///        and while evaluating the point filter
-template <typename GridT, typename PointDataGridT, typename FilterT>
+template <typename GridT, typename PointDataGridT, typename FilterT, typename DeformerT>
 struct PointsToTransformedScalarOp
 {
     using PointDataLeafT = typename PointDataGridT::TreeType::LeafNodeType;
@@ -179,43 +215,71 @@ struct PointsToTransformedScalarOp
     using HandleT = AttributeHandle<Vec3f>;
     using CombinableT = typename GridCombinerOp<GridT>::CombinableT;
 
-    PointsToTransformedScalarOp(const math::Transform& newTransform,
-                         const math::Transform& transform,
-                         const FilterT& filter,
-                         CombinableT& combinable)
-        : mNewTransform(newTransform)
-        , mTransform(transform)
+    PointsToTransformedScalarOp(const math::Transform& targetTransform,
+                                const math::Transform& sourceTransform,
+                                const FilterT& filter,
+                                const DeformerT& deformer,
+                                CombinableT& combinable)
+        : mTargetTransform(targetTransform)
+        , mSourceTransform(sourceTransform)
         , mFilter(filter)
-        , mCombinable(combinable) { }
+        , mCombinable(combinable)
+        , mDeformer(deformer) { }
 
-    void operator()(const PointDataLeafT& leaf, size_t /*idx*/) const
+    void operator()(const PointDataLeafT& leaf, size_t idx) const
     {
+        DeformerT deformer(mDeformer);
+
         auto& grid = mCombinable.local();
         auto& countTree = grid.tree();
         tree::ValueAccessor<typename GridT::TreeType> accessor(countTree);
 
+        deformer.reset(leaf, idx);
+
         auto handle = HandleT::create(leaf.constAttributeArray("P"));
 
         for (auto iter = leaf.beginIndexOn(mFilter); iter; iter++) {
-            const Vec3d position = mTransform.indexToWorld(handle->get(*iter) +
-                iter.getCoord().asVec3d());
-            const Coord ijk = mNewTransform.worldToIndexCellCentered(position);
 
-            accessor.modifyValue(ijk, tools::valxform::SumOp<ValueT>(1));
+            // extract index-space position
+
+            Vec3d position = handle->get(*iter) + iter.getCoord().asVec3d();
+
+            // if deformer is designed to be used in index-space, perform deformation prior
+            // to transforming position to world-space, otherwise perform deformation afterwards
+
+            if (DeformerTraits<DeformerT>::IndexSpace) {
+                deformer.template apply(position, iter);
+                position = mSourceTransform.indexToWorld(position);
+            }
+            else {
+                position = mSourceTransform.indexToWorld(position);
+                deformer.template apply(position, iter);
+            }
+
+            // determine coord of target grid
+
+            const Coord ijk = mTargetTransform.worldToIndexCellCentered(position);
+
+            // increment count in target voxel
+
+            auto* newLeaf = accessor.touchLeaf(ijk);
+            assert(newLeaf);
+            voxelSum(*newLeaf, newLeaf->coordToOffset(ijk), ValueT(1));
         }
     }
 
 private:
-    const openvdb::math::Transform& mNewTransform;
-    const openvdb::math::Transform& mTransform;
+    const openvdb::math::Transform& mTargetTransform;
+    const openvdb::math::Transform& mSourceTransform;
     const FilterT& mFilter;
+    const DeformerT& mDeformer;
     CombinableT& mCombinable;
 }; // struct PointsToTransformedScalarOp
 
 
-template<typename PointDataGridT, typename GridT, typename FilterT>
+template<typename GridT, typename PointDataGridT, typename FilterT>
 inline typename GridT::Ptr convertPointsToScalar(
-    const PointDataGridT& points,
+    PointDataGridT& points,
     const FilterT& filter,
     bool threaded = true)
 {
@@ -259,11 +323,12 @@ inline typename GridT::Ptr convertPointsToScalar(
 }
 
 
-template<typename PointDataGridT, typename GridT, typename FilterT>
+template<typename GridT, typename PointDataGridT, typename FilterT, typename DeformerT>
 inline typename GridT::Ptr convertPointsToScalar(
-    const PointDataGridT& points,
+    PointDataGridT& points,
     const openvdb::math::Transform& transform,
     const FilterT& filter,
+    const DeformerT& deformer,
     bool threaded = true)
 {
     using point_mask_internal::PointsToTransformedScalarOp;
@@ -276,9 +341,8 @@ inline typename GridT::Ptr convertPointsToScalar(
 
     const openvdb::math::Transform& pointsTransform = points.constTransform();
 
-    if (transform == pointsTransform) {
-        return convertPointsToScalar<PointDataGridT, GridT>(
-            points, filter, threaded);
+    if (transform == pointsTransform && std::is_same<NullDeformer, DeformerT>()) {
+        return convertPointsToScalar<GridT>(points, filter, threaded);
     }
 
     typename GridT::Ptr grid = GridT::create();
@@ -292,16 +356,16 @@ inline typename GridT::Ptr convertPointsToScalar(
 
     CombinableT combiner;
 
-    tree::LeafManager<const typename PointDataGridT::TreeType> leafManager(points.tree());
+    tree::LeafManager<typename PointDataGridT::TreeType> leafManager(points.tree());
 
     if (filter.state() == index::ALL) {
         NullFilter nullFilter;
-        PointsToTransformedScalarOp<GridT, PointDataGridT, NullFilter> pointsToScalarOp(
-            transform, pointsTransform, nullFilter, combiner);
+        PointsToTransformedScalarOp<GridT, PointDataGridT, NullFilter, DeformerT> pointsToScalarOp(
+            transform, pointsTransform, nullFilter, deformer, combiner);
         leafManager.foreach(pointsToScalarOp, threaded);
     } else {
-        PointsToTransformedScalarOp<GridT, PointDataGridT, FilterT> pointsToScalarOp(
-            transform, pointsTransform, filter, combiner);
+        PointsToTransformedScalarOp<GridT, PointDataGridT, FilterT, DeformerT> pointsToScalarOp(
+            transform, pointsTransform, filter, deformer, combiner);
         leafManager.foreach(pointsToScalarOp, threaded);
     }
 
@@ -328,8 +392,12 @@ convertPointsToMask(
     const FilterT& filter,
     bool threaded)
 {
-    return point_mask_internal::convertPointsToScalar<PointDataGridT, MaskT>(
-        points, filter, threaded);
+    // This is safe because the PointDataGrid can only be modified by the deformer
+    using AdapterT = TreeAdapter<typename PointDataGridT::TreeType>;
+    auto& nonConstPoints = const_cast<typename AdapterT::NonConstGridType&>(points);
+
+    return point_mask_internal::convertPointsToScalar<MaskT>(
+        nonConstPoints, filter, threaded);
 }
 
 
@@ -342,8 +410,13 @@ convertPointsToMask(
     const FilterT& filter,
     bool threaded)
 {
-    return point_mask_internal::convertPointsToScalar<PointDataGridT, MaskT>(
-        points, transform, filter, threaded);
+    // This is safe because the PointDataGrid can only be modified by the deformer
+    using AdapterT = TreeAdapter<typename PointDataGridT::TreeType>;
+    auto& nonConstPoints = const_cast<typename AdapterT::NonConstGridType&>(points);
+
+    NullDeformer deformer;
+    return point_mask_internal::convertPointsToScalar<MaskT>(
+        nonConstPoints, transform, filter, deformer, threaded);
 }
 
 

--- a/openvdb/points/PointMove.h
+++ b/openvdb/points/PointMove.h
@@ -1,0 +1,991 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2012-2018 DreamWorks Animation LLC
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+//
+/// @author Dan Bailey
+///
+/// @file PointMove.h
+///
+/// @brief Ability to move VDB Points using a custom deformer.
+///
+/// Deformers used when moving points are in world space by default and must adhere
+/// to the interface described in the example below:
+/// @code
+/// struct MyDeformer
+/// {
+///     // A reset is performed on each leaf in turn before the points in that leaf are
+///     // deformed. A leaf and depth-first index within the tree are supplied as the
+///     // arguments, which matches the functor interface for LeafManager::foreach().
+///     template <typename LeafNoteType>
+///     void reset(LeafNoteType& leaf, size_t idx);
+///
+///     // Evaluate the deformer and modify the given position to generate the deformed
+///     // position. An index iterator is supplied as the argument to allow querying the
+///     // point offset or containing voxel coordinate.
+///     template <typename IndexIterT>
+///     void apply(Vec3d& position, const IndexIterT& iter) const;
+/// };
+/// @endcode
+///
+/// @note The DeformerTraits struct (defined in PointMask.h) can be used to configure
+/// a deformer to evaluate in index space.
+
+
+#ifndef OPENVDB_POINTS_POINT_MOVE_HAS_BEEN_INCLUDED
+#define OPENVDB_POINTS_POINT_MOVE_HAS_BEEN_INCLUDED
+
+#include <openvdb/openvdb.h>
+
+#include <openvdb/points/PointDataGrid.h>
+#include <openvdb/points/PointMask.h>
+
+#include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
+#include <tbb/concurrent_vector.h>
+
+#include <vector>
+#include <map>
+#include <unordered_map>
+
+class TestPointMove;
+
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+// dummy object for future use
+namespace future { struct Advect { }; }
+
+
+/// @brief Move points in a PointDataGrid using a custom deformer
+/// @param points           the PointDataGrid containing the points to be moved.
+/// @param deformer         a custom deformer that defines how to move the points.
+/// @param filter           an optional index filter
+/// @param objectNotInUse   for future use, this object is currently ignored
+/// @param threaded         enable or disable threading  (threading is enabled by default)
+template <typename PointDataGridT, typename DeformerT, typename FilterT = NullFilter>
+inline void movePoints(PointDataGridT& points,
+                       DeformerT& deformer,
+                       const FilterT& filter = NullFilter(),
+                       future::Advect* objectNotInUse = nullptr,
+                       bool threaded = true);
+
+
+/// @brief A Deformer that caches the resulting positions from evaluating another Deformer
+template <typename T>
+class CachedDeformer
+{
+public:
+    using Vec3T = typename math::Vec3<T>;
+    using LeafVecT = std::vector<Vec3T>;
+    using LeafMapT = std::unordered_map<Index, Vec3T>;
+
+    // Internal data cache to allow the deformer to offer light-weight copying
+    struct Cache
+    {
+        struct Leaf
+        {
+            /// @brief clear data buffers and reset counter
+            void clear() {
+                vecData.clear();
+                mapData.clear();
+                totalSize = 0;
+            }
+
+            LeafVecT vecData;
+            LeafMapT mapData;
+            Index totalSize = 0;
+        }; // struct Leaf
+
+        std::vector<Leaf> leafs;
+    }; // struct Cache
+
+    /// Cache is expected to be persistent for the lifetime of the CachedDeformer
+    explicit CachedDeformer(Cache& cache);
+
+    /// Caches the result of evaluating the supplied point grid using the deformer and filter
+    /// @param grid         the points to be moved
+    /// @param deformer     the deformer to apply to the points
+    /// @param filter       the point filter to use when evaluating the points
+    /// @param threaded     enable or disable threading  (threading is enabled by default)
+    template <typename PointDataGridT, typename DeformerT, typename FilterT>
+    void evaluate(PointDataGridT& grid, DeformerT& deformer, const FilterT& filter,
+        bool threaded = true);
+
+    /// Stores pointers to the vector or map and optionally expands the map into a vector
+    /// @throw IndexError if idx is out-of-range of the leafs in the cache
+    template <typename LeafT>
+    void reset(const LeafT& leaf, size_t idx);
+
+    /// Retrieve the new position from the cache
+    template <typename IndexIterT>
+    void apply(Vec3d& position, const IndexIterT& iter) const;
+
+private:
+    friend class ::TestPointMove;
+
+    Cache& mCache;
+    LeafVecT mLocalLeafVec;
+    const LeafVecT* mLeafVec = nullptr;
+    const LeafMapT* mLeafMap = nullptr;
+}; // class CachedDeformer
+
+
+////////////////////////////////////////
+
+
+namespace point_move_internal {
+
+
+using IndexTriple = std::tuple<Index, Index, Index>;
+using IndexTripleArray = tbb::concurrent_vector<IndexTriple>;
+using GlobalPointIndexMap = std::unordered_map<Index, IndexTripleArray>;
+
+using IndexPair = std::pair<Index, Index>;
+using IndexPairArray = std::vector<IndexPair>;
+using LocalPointIndexMap = std::unordered_map<Index, IndexPairArray>;
+
+using IndexArray = std::vector<Index>;
+using IndexToIndexMap = std::unordered_map<Index, Index>;
+using OffsetMap = std::unordered_map<Index, IndexArray>;
+
+// TODO: The following infrastructure - ArrayProcessor, PerformTypedMoveOp, processTypedArray()
+// is required to improve AttributeArray copying performance beyond using the virtual function
+// AttributeArray::set(Index, AttributeArray&, Index), however an ABI=6+ addition to AttributeArray
+// could eliminate this cost for the typical case where ValueType and CodecType are the same in
+// source and target arrays, as they are here.
+
+
+/// Helper class used internally by processTypedArray()
+template<typename ValueType, typename OpType>
+struct ArrayProcessor {
+    static inline void call(OpType& op, const AttributeArray& array) {
+#ifdef _MSC_VER
+        op.operator()<ValueType>(array);
+#else
+        op.template operator()<ValueType>(array);
+#endif
+    }
+};
+
+/// @brief Utility function that, given a generic attribute array,
+/// calls a functor with the fully-resolved value type of the array
+template<typename ArrayType, typename OpType>
+bool
+processTypedArray(const ArrayType& array, OpType& op)
+{
+    using namespace openvdb;
+    using namespace openvdb::math;
+    if (array.template hasValueType<bool>())                    ArrayProcessor<bool, OpType>::call(op, array);
+    else if (array.template hasValueType<int16_t>())            ArrayProcessor<int16_t, OpType>::call(op, array);
+    else if (array.template hasValueType<int32_t>())            ArrayProcessor<int32_t, OpType>::call(op, array);
+    else if (array.template hasValueType<int64_t>())            ArrayProcessor<int64_t, OpType>::call(op, array);
+    else if (array.template hasValueType<float>())              ArrayProcessor<float, OpType>::call(op, array);
+    else if (array.template hasValueType<double>())             ArrayProcessor<double, OpType>::call(op, array);
+    else if (array.template hasValueType<Vec3<int32_t>>())      ArrayProcessor<Vec3<int32_t>, OpType>::call(op, array);
+    else if (array.template hasValueType<Vec3<float>>())        ArrayProcessor<Vec3<float>, OpType>::call(op, array);
+    else if (array.template hasValueType<Vec3<double>>())       ArrayProcessor<Vec3<double>, OpType>::call(op, array);
+    else if (array.template hasValueType<GroupType>())          ArrayProcessor<GroupType, OpType>::call(op, array);
+    else if (array.template hasValueType<StringIndexType>())    ArrayProcessor<StringIndexType, OpType>::call(op, array);
+    else if (array.template hasValueType<Mat3<float>>())        ArrayProcessor<Mat3<float>, OpType>::call(op, array);
+    else if (array.template hasValueType<Mat3<double>>())       ArrayProcessor<Mat3<double>, OpType>::call(op, array);
+    else if (array.template hasValueType<Mat4<float>>())        ArrayProcessor<Mat4<float>, OpType>::call(op, array);
+    else if (array.template hasValueType<Mat4<double>>())       ArrayProcessor<Mat4<double>, OpType>::call(op, array);
+    else if (array.template hasValueType<Quat<float>>())        ArrayProcessor<Quat<float>, OpType>::call(op, array);
+    else if (array.template hasValueType<Quat<double>>())       ArrayProcessor<Quat<double>, OpType>::call(op, array);
+    else                                                        return false;
+    return true;
+}
+
+
+/// Cache read and write attribute handles to amortize construction cost
+struct AttributeHandles
+{
+    using HandleArray = std::vector<AttributeHandle<int>::Ptr>;
+
+    AttributeHandles(const size_t size)
+        : mHandles() { mHandles.reserve(size); }
+
+    AttributeArray& getArray(const Index leafOffset)
+    {
+        auto* handle = reinterpret_cast<AttributeWriteHandle<int>*>(mHandles[leafOffset].get());
+        assert(handle);
+        return handle->array();
+    }
+
+    const AttributeArray& getConstArray(const Index leafOffset) const
+    {
+        const auto* handle = mHandles[leafOffset].get();
+        assert(handle);
+        return handle->array();
+    }
+
+    template <typename ValueT>
+    AttributeHandle<ValueT>& getHandle(const Index leafOffset)
+    {
+        auto* handle = reinterpret_cast<AttributeHandle<ValueT>*>(mHandles[leafOffset].get());
+        assert(handle);
+        return *handle;
+    }
+
+    template <typename ValueT>
+    AttributeWriteHandle<ValueT>& getWriteHandle(const Index leafOffset)
+    {
+        auto* handle = reinterpret_cast<AttributeWriteHandle<ValueT>*>(mHandles[leafOffset].get());
+        assert(handle);
+        return *handle;
+    }
+
+    /// Create a handle and reinterpret cast as an int handle to store
+    struct CacheHandleOp
+    {
+        CacheHandleOp(HandleArray& handles)
+            : mHandles(handles) { }
+
+        template<typename ValueT>
+        void operator()(const AttributeArray& array) const
+        {
+            auto* handleAsInt = reinterpret_cast<AttributeHandle<int>*>(
+                new AttributeHandle<ValueT>(array));
+            mHandles.emplace_back(handleAsInt);
+        }
+
+    private:
+        HandleArray& mHandles;
+    }; // struct CacheHandleOp
+
+    template <typename LeafRangeT>
+    void cache(const LeafRangeT& range, const Index attributeIndex)
+    {
+        using namespace openvdb::math;
+
+        mHandles.clear();
+        CacheHandleOp op(mHandles);
+
+        for (auto leaf = range.begin(); leaf; ++leaf) {
+            auto& array = leaf->attributeArray(attributeIndex);
+            processTypedArray(array, op);
+        }
+    }
+
+private:
+    HandleArray mHandles;
+}; // struct AttributeHandles
+
+
+template <typename DeformerT, typename TreeT, typename FilterT>
+struct BuildMoveMapsOp
+{
+    using LeafT = typename TreeT::LeafNodeType;
+    using LeafArrayT = std::vector<LeafT*>;
+    using LeafManagerT = typename tree::LeafManager<TreeT>;
+
+    BuildMoveMapsOp(const DeformerT& deformer,
+                    GlobalPointIndexMap& globalMoveLeafMap,
+                    LocalPointIndexMap& localMoveLeafMap,
+                    const std::map<Coord, Index>& targetLeafMap,
+                    const math::Transform& targetTransform,
+                    const math::Transform& sourceTransform,
+                    const FilterT& filter)
+        : mDeformer(deformer)
+        , mGlobalMoveLeafMap(globalMoveLeafMap)
+        , mLocalMoveLeafMap(localMoveLeafMap)
+        , mTargetLeafMap(targetLeafMap)
+        , mTargetTransform(targetTransform)
+        , mSourceTransform(sourceTransform)
+        , mFilter(filter) { }
+
+    void operator()(LeafT& leaf, size_t idx) const
+    {
+        DeformerT deformer(mDeformer);
+        deformer.reset(leaf, idx);
+
+        // determine source leaf node origin and offset in the source leaf vector
+
+        Coord sourceLeafOrigin = leaf.origin();
+
+        auto sourceHandle = AttributeWriteHandle<Vec3f>::create(leaf.attributeArray("P"));
+
+        for (auto iter = leaf.beginIndexOn(mFilter); iter; iter++) {
+
+            const bool useIndexSpace = DeformerTraits<DeformerT>::IndexSpace;
+
+            // extract index-space position and apply index-space deformation (if applicable)
+
+            Vec3d positionIS = sourceHandle->get(*iter) + iter.getCoord().asVec3d();
+            if (useIndexSpace) {
+               deformer.apply(positionIS, iter);
+            }
+
+            // transform to world-space position and apply world-space deformation (if applicable)
+
+            Vec3d positionWS = mSourceTransform.indexToWorld(positionIS);
+            if (!useIndexSpace) {
+                deformer.apply(positionWS, iter);
+            }
+
+            // transform to index-space position of target grid
+
+            positionIS = mTargetTransform.worldToIndex(positionWS);
+
+            // determine target voxel and offset
+
+            Coord targetVoxel = Coord::round(positionIS);
+            Index targetOffset = LeafT::coordToOffset(targetVoxel);
+
+            // set new local position in source transform space (if point has been deformed)
+
+            Vec3d voxelPosition(positionIS - targetVoxel.asVec3d());
+            sourceHandle->set(*iter, voxelPosition);
+
+            // determine target leaf node origin and offset in the target leaf vector
+
+            Coord targetLeafOrigin = targetVoxel & ~(LeafT::DIM - 1);
+            assert(mTargetLeafMap.find(targetLeafOrigin) != mTargetLeafMap.end());
+            const Index targetLeafOffset(mTargetLeafMap.at(targetLeafOrigin));
+
+            // insert into move map based on whether point ends up in a new leaf node or not
+
+            if (targetLeafOrigin == sourceLeafOrigin) {
+                mLocalMoveLeafMap[targetLeafOffset].emplace_back(targetOffset, *iter);
+            }
+            else {
+                mGlobalMoveLeafMap[targetLeafOffset].push_back(IndexTriple(idx,
+                    targetOffset, *iter));
+            }
+        }
+    }
+
+private:
+    const DeformerT& mDeformer;
+    GlobalPointIndexMap& mGlobalMoveLeafMap;
+    LocalPointIndexMap& mLocalMoveLeafMap;
+    const std::map<Coord, Index>& mTargetLeafMap;
+    const math::Transform& mTargetTransform;
+    const math::Transform& mSourceTransform;
+    const FilterT& mFilter;
+}; // struct BuildMoveMapsOp
+
+template <typename LeafT>
+inline Index
+indexOffsetFromVoxel(const Index voxelOffset, const LeafT& leaf, IndexArray& offsets)
+{
+    // compute the target point index by summing the point index of the previous
+    // voxel with the current number of points added to this voxel, tracked by the
+    // offsets array
+
+    Index targetOffset = Index(offsets[voxelOffset]++);
+    if (voxelOffset > 0) {
+        targetOffset += Index(leaf.getValue(voxelOffset - 1));
+    }
+    return targetOffset;
+}
+
+template <typename TreeT>
+struct GlobalMovePointsOp
+{
+    using LeafT = typename TreeT::LeafNodeType;
+    using LeafArrayT = std::vector<LeafT*>;
+    using LeafManagerT = typename tree::LeafManager<TreeT>;
+
+    GlobalMovePointsOp(OffsetMap& offsetMap,
+                       AttributeHandles& targetHandles,
+                       AttributeHandles& sourceHandles,
+                       const Index attributeIndex,
+                       const GlobalPointIndexMap& moveLeafMap)
+        : mOffsetMap(offsetMap)
+        , mTargetHandles(targetHandles)
+        , mSourceHandles(sourceHandles)
+        , mAttributeIndex(attributeIndex)
+        , mMoveLeafMap(moveLeafMap) { }
+
+    struct PerformTypedMoveOp
+    {
+        PerformTypedMoveOp(AttributeHandles& targetHandles, AttributeHandles& sourceHandles,
+            int targetOffset, const LeafT& targetLeaf,
+            IndexArray& offsets, const IndexTripleArray& indices)
+            : mTargetHandles(targetHandles)
+            , mSourceHandles(sourceHandles)
+            , mTargetOffset(targetOffset)
+            , mTargetLeaf(targetLeaf)
+            , mOffsets(offsets)
+            , mIndices(indices) { }
+
+        template<typename ValueT>
+        void operator()(const AttributeArray&) const
+        {
+            auto& targetHandle = mTargetHandles.getWriteHandle<ValueT>(mTargetOffset);
+            targetHandle.expand();
+
+            for (const auto& it : mIndices) {
+                const auto& sourceHandle = mSourceHandles.getHandle<ValueT>(std::get<0>(it));
+                const Index targetIndex = indexOffsetFromVoxel(std::get<1>(it), mTargetLeaf, mOffsets);
+                for (Index i = 0; i < sourceHandle.stride(); i++) {
+                    ValueT sourceValue = sourceHandle.get(std::get<2>(it), i);
+                    targetHandle.set(targetIndex, i, sourceValue);
+                }
+            }
+        }
+
+    private:
+        AttributeHandles& mTargetHandles;
+        AttributeHandles& mSourceHandles;
+        int mTargetOffset;
+        const LeafT& mTargetLeaf;
+        IndexArray& mOffsets;
+        const IndexTripleArray& mIndices;
+    }; // struct PerformTypedMoveOp
+
+    void performMove(int targetOffset, const LeafT& targetLeaf,
+        IndexArray& offsets, const IndexTripleArray& indices) const
+    {
+        auto& targetArray = mTargetHandles.getArray(targetOffset);
+
+        for (const auto& it : indices) {
+            const auto& sourceArray = mSourceHandles.getConstArray(std::get<0>(it));
+            const Index targetOffset = indexOffsetFromVoxel(std::get<1>(it), targetLeaf, offsets);
+            targetArray.set(targetOffset, sourceArray, std::get<2>(it));
+        }
+    }
+
+    void operator()(const typename LeafManagerT::LeafRange& range) const
+    {
+        for (auto leaf = range.begin(); leaf; ++leaf) {
+
+            const auto& moveIndices = mMoveLeafMap.at(leaf.pos());
+            if (moveIndices.empty())  continue;
+
+            // extract per-voxel offsets for this leaf
+
+            auto& offsets = mOffsetMap[leaf.pos()];
+
+            const auto& array = leaf->constAttributeArray(mAttributeIndex);
+
+            PerformTypedMoveOp op(mTargetHandles, mSourceHandles, leaf.pos(), *leaf, offsets, moveIndices);
+            if (!processTypedArray(array, op)) {
+                this->performMove(leaf.pos(), *leaf, offsets, moveIndices);
+            }
+        }
+    }
+
+private:
+    OffsetMap& mOffsetMap;
+    AttributeHandles& mTargetHandles;
+    AttributeHandles& mSourceHandles;
+    const Index mAttributeIndex;
+    const GlobalPointIndexMap& mMoveLeafMap;
+}; // struct GlobalMovePointsOp
+
+template <typename TreeT>
+struct LocalMovePointsOp
+{
+    using LeafT = typename TreeT::LeafNodeType;
+    using LeafArrayT = std::vector<LeafT*>;
+    using LeafManagerT = typename tree::LeafManager<TreeT>;
+    using IndexToIndexMap = std::unordered_map<Index, Index>;
+
+    LocalMovePointsOp(OffsetMap& offsetMap,
+                       AttributeHandles& targetHandles,
+                       const IndexToIndexMap& targetToSourceMap,
+                       AttributeHandles& sourceHandles,
+                       const Index attributeIndex,
+                       const LocalPointIndexMap& moveLeafMap)
+        : mOffsetMap(offsetMap)
+        , mTargetHandles(targetHandles)
+        , mTargetToSourceMap(targetToSourceMap)
+        , mSourceHandles(sourceHandles)
+        , mAttributeIndex(attributeIndex)
+        , mMoveLeafMap(moveLeafMap) { }
+
+    struct PerformTypedMoveOp
+    {
+        PerformTypedMoveOp(AttributeHandles& targetHandles, AttributeHandles& sourceHandles,
+            int targetOffset, int sourceOffset, const LeafT& targetLeaf,
+            IndexArray& offsets, const IndexPairArray& indices)
+            : mTargetHandles(targetHandles)
+            , mSourceHandles(sourceHandles)
+            , mTargetOffset(targetOffset)
+            , mSourceOffset(sourceOffset)
+            , mTargetLeaf(targetLeaf)
+            , mOffsets(offsets)
+            , mIndices(indices) { }
+
+        template<typename ValueT>
+        void operator()(const AttributeArray&) const
+        {
+            auto& targetHandle = mTargetHandles.getWriteHandle<ValueT>(mTargetOffset);
+            const auto& sourceHandle = mSourceHandles.getHandle<ValueT>(mSourceOffset);
+
+            targetHandle.expand();
+
+            for (const auto& it : mIndices) {
+                const Index targetIndex = indexOffsetFromVoxel(it.first, mTargetLeaf, mOffsets);
+                for (Index i = 0; i < sourceHandle.stride(); i++) {
+                    ValueT sourceValue = sourceHandle.get(it.second, i);
+                    targetHandle.set(targetIndex, i, sourceValue);
+                }
+            }
+        }
+
+    private:
+        AttributeHandles& mTargetHandles;
+        AttributeHandles& mSourceHandles;
+        int mTargetOffset;
+        int mSourceOffset;
+        const LeafT& mTargetLeaf;
+        IndexArray& mOffsets;
+        const IndexPairArray& mIndices;
+    }; // struct PerformTypedMoveOp
+
+    template <typename ValueT>
+    void performTypedMove(int sourceOffset, int targetOffset, const LeafT& targetLeaf,
+        IndexArray& offsets, const IndexPairArray& indices) const
+    {
+        auto& targetHandle = mTargetHandles.getWriteHandle<ValueT>(targetOffset);
+        const auto& sourceHandle = mSourceHandles.getHandle<ValueT>(sourceOffset);
+
+        targetHandle.expand();
+
+        for (const auto& it : indices) {
+            const Index targetOffset = indexOffsetFromVoxel(it.first, targetLeaf, offsets);
+            for (Index i = 0; i < sourceHandle.stride(); i++) {
+                ValueT sourceValue = sourceHandle.get(it.second, i);
+                targetHandle.set(targetOffset, i, sourceValue);
+            }
+        }
+    }
+
+    void performMove(int targetOffset, int sourceOffset, const LeafT& targetLeaf,
+        IndexArray& offsets, const IndexPairArray& indices) const
+    {
+        auto& targetArray = mTargetHandles.getArray(targetOffset);
+        const auto& sourceArray = mSourceHandles.getConstArray(sourceOffset);
+
+        for (const auto& it : indices) {
+            const Index targetOffset = indexOffsetFromVoxel(it.first, targetLeaf, offsets);
+            targetArray.set(targetOffset, sourceArray, it.second);
+        }
+    }
+
+    void operator()(const typename LeafManagerT::LeafRange& range) const
+    {
+        for (auto leaf = range.begin(); leaf; ++leaf) {
+
+            const auto& moveIndices = mMoveLeafMap.at(leaf.pos());
+            if (moveIndices.empty())  continue;
+
+            // extract target leaf and per-voxel offsets for this leaf
+
+            auto& offsets = mOffsetMap[leaf.pos()];
+
+            // extract source leaf that has the same origin as the target leaf (if any)
+
+            const auto it = mTargetToSourceMap.find(leaf.pos());
+            assert(it != mTargetToSourceMap.end());
+
+            const Index sourceOffset(it->second);
+
+            const auto& array = leaf->constAttributeArray(mAttributeIndex);
+
+            PerformTypedMoveOp op(mTargetHandles, mSourceHandles,
+                leaf.pos(), sourceOffset, *leaf, offsets, moveIndices);
+            if (!processTypedArray(array, op)) {
+                this->performMove(leaf.pos(), sourceOffset, *leaf, offsets, moveIndices);
+            }
+        }
+    }
+
+private:
+    OffsetMap& mOffsetMap;
+    AttributeHandles& mTargetHandles;
+    const IndexToIndexMap& mTargetToSourceMap;
+    AttributeHandles& mSourceHandles;
+    const Index mAttributeIndex;
+    const LocalPointIndexMap& mMoveLeafMap;
+}; // struct LocalMovePointsOp
+
+} // namespace point_move_internal
+
+
+////////////////////////////////////////
+
+
+template <typename PointDataGridT, typename DeformerT, typename FilterT>
+inline void movePoints( PointDataGridT& points,
+                        DeformerT& deformer,
+                        const FilterT& filter,
+                        future::Advect* objectNotInUse,
+                        bool threaded)
+{
+    using PointDataTreeT = typename PointDataGridT::TreeType;
+    using LeafNode = typename PointDataTreeT::LeafNodeType;
+    using LeafManagerT = typename tree::LeafManager<PointDataTreeT>;
+    using LeafRangeT = typename LeafManagerT::LeafRange;
+
+    using namespace point_move_internal;
+
+    // this object is for future use only
+    assert(!objectNotInUse);
+
+    PointDataTreeT& tree = points.tree();
+
+    // early exit if no LeafNodes
+
+    PointDataTree::LeafCIter iter = tree.cbeginLeaf();
+
+    if (!iter)      return;
+
+    // build voxel topology taking into account any point group deletion
+
+    auto newPoints = point_mask_internal::convertPointsToScalar<PointDataGrid>(
+        points, points.transform(), filter, deformer, threaded);
+    auto& newTree = newPoints->tree();
+
+    // create leaf managers for both trees
+
+    LeafManagerT sourceLeafManager(tree);
+    LeafManagerT targetLeafManager(newTree);
+
+    // initialize attribute handles
+    AttributeHandles sourceHandles(sourceLeafManager.leafCount());
+    AttributeHandles targetHandles(targetLeafManager.leafCount());
+
+    // map frequency to cumulative histogram
+    auto histogramLambda = [](const LeafRangeT& range) {
+        for (auto leaf = range.begin(); leaf; ++leaf) {
+            auto* buffer = leaf->buffer().data();
+            for (int i = 1; i < leaf->buffer().size(); i++) {
+                buffer[i] = buffer[i-1] + buffer[i];
+            }
+        }
+    };
+    if (threaded) {
+        tbb::parallel_for(targetLeafManager.leafRange(), histogramLambda);
+    } else {
+        histogramLambda(targetLeafManager.leafRange());
+    }
+
+    // build a coord -> index map for looking up target leafs by origin and a faster
+    // unordered map for finding the source index from a target index
+
+    std::map<Coord, Index> targetLeafMap;
+    std::unordered_map<Index, Index> targetToSourceMap;
+
+    {
+        std::map<Coord, Index> sourceLeafMap;
+        auto sourceRange = sourceLeafManager.leafRange();
+        for (auto leaf = sourceRange.begin(); leaf; ++leaf) {
+            sourceLeafMap.insert({leaf->origin(), leaf.pos()});
+        }
+        auto targetRange = targetLeafManager.leafRange();
+        for (auto leaf = targetRange.begin(); leaf; ++leaf) {
+            targetLeafMap.insert({leaf->origin(), leaf.pos()});
+            const auto it = sourceLeafMap.find(leaf->origin());
+            if (it != sourceLeafMap.end()) {
+                targetToSourceMap.insert({leaf.pos(), it->second});
+            }
+        }
+    }
+
+    // replace attribute set with a copy of the existing one
+    const auto& existingAttributeSet = points.tree().cbeginLeaf()->attributeSet();
+    auto replaceAttributeSetLambda = [&existingAttributeSet](const LeafRangeT& range) {
+        for (auto leaf = range.begin(); leaf; ++leaf) {
+            leaf->replaceAttributeSet(new AttributeSet(existingAttributeSet, leaf->getLastValue()),
+                /*allowMismatchingDescriptors=*/true);
+        }
+    };
+    if (threaded) {
+        tbb::parallel_for(targetLeafManager.leafRange(),replaceAttributeSetLambda);
+    } else {
+        replaceAttributeSetLambda(targetLeafManager.leafRange());
+    }
+
+    // moving leaf
+
+    GlobalPointIndexMap globalMoveLeafMap;
+    LocalPointIndexMap localMoveLeafMap;
+
+    // initialize move leaf maps and offsets
+
+    OffsetMap offsetMap;
+
+    for (size_t n = 0; n < targetLeafManager.leafCount(); n++) {
+        globalMoveLeafMap.insert({n, IndexTripleArray()});
+        localMoveLeafMap.insert({n, IndexPairArray()});
+        offsetMap.insert({n, IndexArray(LeafNode::SIZE)});
+    }
+
+    // build global and local move leaf maps and update local positions
+
+    if (filter.state() == index::ALL) {
+        NullFilter nullFilter;
+        BuildMoveMapsOp<DeformerT, PointDataTreeT, NullFilter> op(deformer,
+            globalMoveLeafMap, localMoveLeafMap, targetLeafMap,
+            points.transform(), points.transform(), nullFilter);
+        sourceLeafManager.foreach(op, threaded);
+    } else {
+        BuildMoveMapsOp<DeformerT, PointDataTreeT, FilterT> op(deformer,
+            globalMoveLeafMap, localMoveLeafMap, targetLeafMap,
+            points.transform(), points.transform(), filter);
+        sourceLeafManager.foreach(op, threaded);
+    }
+
+    for (const auto& it : existingAttributeSet.descriptor().map()) {
+
+        const Index attributeIndex = it.second;
+
+        // zero offsets
+        auto zeroOffsetsLambda = [&offsetMap](const LeafRangeT& range) {
+            for (auto leaf = range.begin(); leaf; ++leaf) {
+                std::fill(offsetMap[leaf.pos()].begin(), offsetMap[leaf.pos()].end(), 0);
+            }
+        };
+        if (threaded) {
+            tbb::parallel_for(targetLeafManager.leafRange(), zeroOffsetsLambda);
+        } else {
+            zeroOffsetsLambda(targetLeafManager.leafRange());
+        }
+
+        // cache attribute handles
+
+        sourceHandles.cache(sourceLeafManager.leafRange(), attributeIndex);
+        targetHandles.cache(targetLeafManager.leafRange(), attributeIndex);
+
+        // move points between leaf nodes
+
+        GlobalMovePointsOp<PointDataTreeT> globalMoveOp(offsetMap, targetHandles,
+            sourceHandles, attributeIndex, globalMoveLeafMap);
+        if (threaded) {
+            tbb::parallel_for(targetLeafManager.leafRange(), globalMoveOp);
+        } else {
+            globalMoveOp(targetLeafManager.leafRange());
+        }
+
+        // move points within leaf nodes
+
+        LocalMovePointsOp<PointDataTreeT> localMoveOp(offsetMap, targetHandles,
+            targetToSourceMap, sourceHandles,
+            attributeIndex, localMoveLeafMap);
+        if (threaded) {
+            tbb::parallel_for(targetLeafManager.leafRange(), localMoveOp);
+        } else {
+            localMoveOp(targetLeafManager.leafRange());
+        }
+    }
+
+    points.setTree(newPoints->treePtr());
+}
+
+
+////////////////////////////////////////
+
+
+template <typename T>
+CachedDeformer<T>::CachedDeformer(Cache& cache)
+    : mCache(cache) { }
+
+
+template <typename T>
+template <typename PointDataGridT, typename DeformerT, typename FilterT>
+void CachedDeformer<T>::evaluate(PointDataGridT& grid, DeformerT& deformer, const FilterT& filter,
+    bool threaded)
+{
+    using TreeT = typename PointDataGridT::TreeType;
+    using LeafT = typename TreeT::LeafNodeType;
+    using LeafManagerT = typename tree::LeafManager<TreeT>;
+    using LeafRangeT = typename LeafManagerT::LeafRange;
+    LeafManagerT leafManager(grid.tree());
+
+    // initialize cache
+    auto& leafs = mCache.leafs;
+    leafs.resize(leafManager.leafCount());
+
+    const auto& transform = grid.transform();
+
+    // insert deformed positions into the cache
+
+    auto cachePositionsLambda = [&transform, &deformer, &leafs, &filter](
+        const LeafRangeT& range) {
+
+        // deformer is copied to ensure that it is unique per-thread
+
+        DeformerT newDeformer(deformer);
+
+        for (auto leaf = range.begin(); leaf; ++leaf) {
+
+            const Index64 totalPointCount = leaf->pointCount();
+            if (totalPointCount == 0)   continue;
+
+            // if more than half the number of total points are evaluated by the filter, prefer
+            // accessing the data from a vector instead of a hash map for faster performance
+            const Index64 vectorThreshold = totalPointCount / 2;
+
+            newDeformer.reset(*leaf, leaf.pos());
+
+            auto handle = AttributeHandle<Vec3f>::create(leaf->constAttributeArray("P"));
+
+            auto& cache = leafs[leaf.pos()];
+            cache.clear();
+
+            // only insert into a vector directly if the filter evaluates all points and the
+            // number of active points is greater than the vector threshold
+            const bool useVector = filter.state() == index::ALL &&
+                (leaf->isDense() || (leaf->onPointCount() > vectorThreshold));
+            if (useVector) {
+                cache.vecData.resize(totalPointCount);
+            }
+
+            for (auto iter = leaf->beginIndexOn(filter); iter; iter++) {
+
+                // extract index-space position and apply index-space deformation (if defined)
+
+                Vec3d position = handle->get(*iter) + iter.getCoord().asVec3d();
+
+                // if deformer is designed to be used in index-space, perform deformation prior
+                // to transforming position to world-space, otherwise perform deformation afterwards
+
+                if (DeformerTraits<DeformerT>::IndexSpace) {
+                    newDeformer.apply(position, iter);
+                    position = transform.indexToWorld(position);
+                }
+                else {
+                    position = transform.indexToWorld(position);
+                    newDeformer.apply(position, iter);
+                }
+
+                // insert new position into the cache
+
+                if (useVector) {
+                    cache.vecData[*iter] = static_cast<Vec3T>(position);
+                }
+                else {
+                    cache.mapData.insert({*iter, static_cast<Vec3T>(position)});
+                }
+            }
+
+            // after insertion, move the data into a vector if the threshold is reached
+
+            if (!useVector && cache.mapData.size() > vectorThreshold) {
+                cache.vecData.resize(totalPointCount);
+                for (const auto& it : cache.mapData) {
+                    cache.vecData[it.first] = it.second;
+                }
+                cache.mapData.clear();
+            }
+
+            // store the total number of points to allow use of an expanded vector on access
+
+            if (!cache.mapData.empty()) {
+                cache.totalSize = totalPointCount;
+            }
+        }
+    };
+
+    if (threaded) {
+        tbb::parallel_for(leafManager.leafRange(), cachePositionsLambda);
+    } else {
+        cachePositionsLambda(leafManager.leafRange());
+    }
+}
+
+
+template <typename T>
+template <typename LeafT>
+void CachedDeformer<T>::reset(const LeafT& /*leaf*/, size_t idx)
+{
+    if (idx >= mCache.leafs.size()) {
+        if (mCache.leafs.empty()) {
+            throw IndexError("No leafs in cache, perhaps CachedDeformer has not been evaluated?");
+        } else {
+            throw IndexError("Leaf index is out-of-range of cache leafs.");
+        }
+    }
+    auto& cache = mCache.leafs[idx];
+    if (!cache.mapData.empty()) {
+        // expand into a local vector if there are greater than 16 values in the hash map
+        // and the expanded vector would contain fewer values than 256 times those in the
+        // hash map, this trades a little extra storage for faster random access performance
+        if (cache.mapData.size() > 16 &&
+            cache.totalSize < (cache.mapData.size() * 256)) {
+            if (cache.totalSize < cache.mapData.size()) {
+                throw ValueError("Cache total size is not valid.");
+            }
+            mLocalLeafVec.resize(cache.totalSize);
+            for (const auto& it : cache.mapData) {
+                assert(it.first < cache.totalSize);
+                mLocalLeafVec[it.first] = it.second;
+            }
+            mLeafVec = &mLocalLeafVec;
+            mLeafMap = nullptr;
+        }
+        else {
+            mLeafMap = &cache.mapData;
+            mLeafVec = nullptr;
+        }
+    }
+    else {
+        mLeafVec = &cache.vecData;
+        mLeafMap = nullptr;
+    }
+}
+
+
+template <typename T>
+template <typename IndexIterT>
+void CachedDeformer<T>::apply(Vec3d& position, const IndexIterT& iter) const
+{
+    assert(*iter >= 0);
+
+    if (mLeafMap) {
+        auto it = mLeafMap->find(*iter);
+        if (it == mLeafMap->end())      return;
+        position = static_cast<openvdb::Vec3d>(it->second);
+    }
+    else {
+        assert(mLeafVec);
+
+        if (mLeafVec->empty())          return;
+        assert(*iter < mLeafVec->size());
+        position = static_cast<openvdb::Vec3d>((*mLeafVec)[*iter]);
+    }
+}
+
+
+} // namespace points
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+#endif // OPENVDB_POINTS_POINT_MOVE_HAS_BEEN_INCLUDED
+
+// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/unittest/TestAttributeArray.cc
+++ b/openvdb/unittest/TestAttributeArray.cc
@@ -812,6 +812,9 @@ TestAttributeArray::testAccessorEval()
 
         AttributeHandle<float, NullCodec> handle(array);
 
+        const AttributeArray& constArray(array);
+        CPPUNIT_ASSERT_EQUAL(&constArray, &handle.array());
+
         handle.mGetter = TestAccessor::getterError;
 
         const float result1 = handle.get(4);
@@ -831,6 +834,8 @@ TestAttributeArray::testAccessorEval()
         // unknown codec is used here so getter and setter are called
 
         AttributeWriteHandle<float, UnknownCodec> writeHandle(array);
+
+        CPPUNIT_ASSERT_EQUAL(&array, &writeHandle.array());
 
         writeHandle.mSetter = TestAccessor::setterError;
 

--- a/openvdb/unittest/TestPointAdvect.cc
+++ b/openvdb/unittest/TestPointAdvect.cc
@@ -1,0 +1,485 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2012-2018 DreamWorks Animation LLC
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <openvdb/unittest/util.h>
+#include <openvdb/points/PointAttribute.h>
+#include <openvdb/points/PointDataGrid.h>
+#include <openvdb/points/PointConversion.h>
+#include <openvdb/points/PointScatter.h>
+#include <openvdb/points/PointAdvect.h>
+#include <openvdb/tools/LevelSetSphere.h>
+#include <openvdb/tools/Composite.h> // csgDifference
+#include <openvdb/tools/MeshToVolume.h> // createLevelSetBox
+#include <openvdb/openvdb.h>
+
+#include <openvdb/Types.h>
+
+using namespace openvdb;
+using namespace openvdb::points;
+
+class TestPointAdvect: public CppUnit::TestCase
+{
+public:
+
+    virtual void setUp() { openvdb::initialize(); }
+    virtual void tearDown() { openvdb::uninitialize(); }
+
+    CPPUNIT_TEST_SUITE(TestPointAdvect);
+    CPPUNIT_TEST(testAdvect);
+    CPPUNIT_TEST(testZalesaksDisk);
+    CPPUNIT_TEST_SUITE_END();
+
+    void testAdvect();
+    void testZalesaksDisk();
+}; // class TestPointAdvect
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestPointAdvect);
+
+
+////////////////////////////////////////
+
+
+void
+TestPointAdvect::testAdvect()
+{
+    // generate four points
+
+    const float voxelSize = 1.0f;
+    std::vector<Vec3s> positions =  {
+                                    {5, 2, 3},
+                                    {2, 4, 1},
+                                    {50, 5, 1},
+                                    {3, 20, 1},
+                                };
+
+    const PointAttributeVector<Vec3s> pointList(positions);
+
+    math::Transform::Ptr pointTransform(math::Transform::createLinearTransform(voxelSize));
+
+    auto pointIndexGrid = tools::createPointIndexGrid<tools::PointIndexGrid>(
+        pointList, *pointTransform);
+
+    auto points = createPointDataGrid<NullCodec, PointDataGrid>(
+        *pointIndexGrid, pointList, *pointTransform);
+
+    std::vector<int> id;
+    id.push_back(0);
+    id.push_back(1);
+    id.push_back(2);
+    id.push_back(3);
+
+    auto idAttributeType = TypedAttributeArray<int>::attributeType();
+    appendAttribute(points->tree(), "id", idAttributeType);
+
+    // create a wrapper around the id vector
+    PointAttributeVector<int> idWrapper(id);
+
+    populateAttribute<PointDataTree, tools::PointIndexTree, PointAttributeVector<int>>(
+            points->tree(), pointIndexGrid->tree(), "id", idWrapper);
+
+    // create "test" group which only contains third point
+
+    appendGroup(points->tree(), "test");
+    std::vector<short> groups(positions.size(), 0);
+    groups[2] = 1;
+    setGroup(points->tree(), pointIndexGrid->tree(), groups, "test");
+
+    // create "test2" group which contains second and third point
+
+    appendGroup(points->tree(), "test2");
+    groups[1] = 1;
+    setGroup(points->tree(), pointIndexGrid->tree(), groups, "test2");
+
+    const Vec3s tolerance(1e-3f);
+
+    // advect by velocity using all integration orders
+
+    for (Index integrationOrder = 0; integrationOrder < 5; integrationOrder++) {
+        Vec3s velocityBackground(1.0, 2.0, 3.0);
+        double timeStep = 1.0;
+        int steps = 1;
+        auto velocity = Vec3SGrid::create(velocityBackground); // grid with background value only
+
+        auto pointsToAdvect = points->deepCopy();
+        const auto& transform = pointsToAdvect->transform();
+
+        advectPoints(*pointsToAdvect, *velocity, integrationOrder, timeStep, steps);
+
+        for (auto leaf = pointsToAdvect->tree().beginLeaf(); leaf; ++leaf) {
+            AttributeHandle<Vec3s> positionHandle(leaf->constAttributeArray("P"));
+            AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+            for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+                int id = idHandle.get(*iter);
+                Vec3s position = transform.indexToWorld(
+                    positionHandle.get(*iter) + iter.getCoord().asVec3d());
+                Vec3s expectedPosition(positions[id]);
+                if (integrationOrder > 0)   expectedPosition += velocityBackground;
+                CPPUNIT_ASSERT(math::isApproxEqual(position, expectedPosition, tolerance));
+            }
+        }
+    }
+
+    // invalid advection scheme
+
+    auto zeroVelocityGrid = Vec3SGrid::create(Vec3s(0));
+    CPPUNIT_ASSERT_THROW(advectPoints(*points, *zeroVelocityGrid, 5, 1.0, 1), ValueError);
+
+    { // advect varying dt and steps
+        Vec3s velocityBackground(1.0, 2.0, 3.0);
+        Index integrationOrder = 4;
+        double timeStep = 0.1;
+        int steps = 100;
+        auto velocity = Vec3SGrid::create(velocityBackground); // grid with background value only
+
+        auto pointsToAdvect = points->deepCopy();
+        const auto& transform = pointsToAdvect->transform();
+
+        advectPoints(*pointsToAdvect, *velocity, integrationOrder, timeStep, steps);
+
+        for (auto leaf = pointsToAdvect->tree().beginLeaf(); leaf; ++leaf) {
+            AttributeHandle<Vec3s> positionHandle(leaf->constAttributeArray("P"));
+            AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+            for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+                int id = idHandle.get(*iter);
+                Vec3s position = transform.indexToWorld(
+                    positionHandle.get(*iter) + iter.getCoord().asVec3d());
+                Vec3s expectedPosition(positions[id] + velocityBackground * 10);
+                CPPUNIT_ASSERT(math::isApproxEqual(position, expectedPosition, tolerance));
+            }
+        }
+    }
+
+    { // perform filtered advection
+        Vec3s velocityBackground(1.0, 2.0, 3.0);
+        Index integrationOrder = 4;
+        double timeStep = 1.0;
+        int steps = 1;
+        auto velocity = Vec3SGrid::create(velocityBackground); // grid with background value only
+
+        std::vector<std::string> advectIncludeGroups;
+        std::vector<std::string> advectExcludeGroups;
+        std::vector<std::string> includeGroups;
+        std::vector<std::string> excludeGroups;
+
+        { // only advect points in "test" group
+            advectIncludeGroups.push_back("test");
+
+            auto leaf = points->tree().cbeginLeaf();
+            MultiGroupFilter advectFilter(advectIncludeGroups, advectExcludeGroups, leaf->attributeSet());
+            MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+
+            auto pointsToAdvect = points->deepCopy();
+            const auto& transform = pointsToAdvect->transform();
+
+            advectPoints(*pointsToAdvect, *velocity, integrationOrder, timeStep, steps,
+                advectFilter, filter);
+
+            CPPUNIT_ASSERT_EQUAL(Index64(4), pointCount(pointsToAdvect->tree()));
+
+            for (auto leaf = pointsToAdvect->tree().beginLeaf(); leaf; ++leaf) {
+                AttributeHandle<Vec3s> positionHandle(leaf->constAttributeArray("P"));
+                AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+                for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+                    int id = idHandle.get(*iter);
+                    Vec3s position = transform.indexToWorld(
+                        positionHandle.get(*iter) + iter.getCoord().asVec3d());
+                    Vec3s expectedPosition(positions[id]);
+                    if (id == 2)    expectedPosition += velocityBackground;
+                    CPPUNIT_ASSERT(math::isApproxEqual(position, expectedPosition, tolerance));
+                }
+            }
+
+            advectIncludeGroups.clear();
+        }
+
+        { // only keep points in "test" group
+            includeGroups.push_back("test");
+
+            auto leaf = points->tree().cbeginLeaf();
+            MultiGroupFilter advectFilter(advectIncludeGroups, advectExcludeGroups, leaf->attributeSet());
+            MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+
+            auto pointsToAdvect = points->deepCopy();
+            const auto& transform = pointsToAdvect->transform();
+
+            advectPoints(*pointsToAdvect, *velocity, integrationOrder, timeStep, steps,
+                advectFilter, filter);
+
+            CPPUNIT_ASSERT_EQUAL(Index64(1), pointCount(pointsToAdvect->tree()));
+
+            for (auto leaf = pointsToAdvect->tree().beginLeaf(); leaf; ++leaf) {
+                AttributeHandle<Vec3s> positionHandle(leaf->constAttributeArray("P"));
+                AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+                for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+                    int id = idHandle.get(*iter);
+                    Vec3s position = transform.indexToWorld(
+                        positionHandle.get(*iter) + iter.getCoord().asVec3d());
+                    Vec3s expectedPosition(positions[id]);
+                    expectedPosition += velocityBackground;
+                    CPPUNIT_ASSERT(math::isApproxEqual(position, expectedPosition, tolerance));
+                }
+            }
+
+            includeGroups.clear();
+        }
+
+        { // only advect points in "test2" group, delete points in "test" group
+            advectIncludeGroups.push_back("test2");
+            excludeGroups.push_back("test");
+
+            auto leaf = points->tree().cbeginLeaf();
+            MultiGroupFilter advectFilter(advectIncludeGroups, advectExcludeGroups, leaf->attributeSet());
+            MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+
+            auto pointsToAdvect = points->deepCopy();
+            const auto& transform = pointsToAdvect->transform();
+
+            advectPoints(*pointsToAdvect, *velocity, integrationOrder, timeStep, steps,
+                advectFilter, filter);
+
+            CPPUNIT_ASSERT_EQUAL(Index64(3), pointCount(pointsToAdvect->tree()));
+
+            for (auto leaf = pointsToAdvect->tree().beginLeaf(); leaf; ++leaf) {
+                AttributeHandle<Vec3s> positionHandle(leaf->constAttributeArray("P"));
+                AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+                for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+                    int id = idHandle.get(*iter);
+                    Vec3s position = transform.indexToWorld(
+                        positionHandle.get(*iter) + iter.getCoord().asVec3d());
+                    Vec3s expectedPosition(positions[id]);
+                    if (id == 1)    expectedPosition += velocityBackground;
+                    CPPUNIT_ASSERT(math::isApproxEqual(position, expectedPosition, tolerance));
+                }
+            }
+
+            advectIncludeGroups.clear();
+            excludeGroups.clear();
+        }
+
+        { // advect all points, caching disabled
+            auto pointsToAdvect = points->deepCopy();
+            const auto& transform = pointsToAdvect->transform();
+
+            auto leaf = points->tree().cbeginLeaf();
+            MultiGroupFilter advectFilter(advectIncludeGroups, advectExcludeGroups, leaf->attributeSet());
+            MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+
+            advectPoints(*pointsToAdvect, *velocity, integrationOrder, timeStep, steps,
+                advectFilter, filter, false);
+
+            CPPUNIT_ASSERT_EQUAL(Index64(4), pointCount(pointsToAdvect->tree()));
+
+            for (auto leaf = pointsToAdvect->tree().beginLeaf(); leaf; ++leaf) {
+                AttributeHandle<Vec3s> positionHandle(leaf->constAttributeArray("P"));
+                AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+                for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+                    int id = idHandle.get(*iter);
+                    Vec3s position = transform.indexToWorld(
+                        positionHandle.get(*iter) + iter.getCoord().asVec3d());
+                    Vec3s expectedPosition(positions[id]);
+                    expectedPosition += velocityBackground;
+                    CPPUNIT_ASSERT(math::isApproxEqual(position, expectedPosition, tolerance));
+                }
+            }
+        }
+
+        { // only advect points in "test2" group, delete points in "test" group, caching disabled
+            advectIncludeGroups.push_back("test2");
+            excludeGroups.push_back("test");
+
+            auto leaf = points->tree().cbeginLeaf();
+            MultiGroupFilter advectFilter(advectIncludeGroups, advectExcludeGroups, leaf->attributeSet());
+            MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+
+            auto pointsToAdvect = points->deepCopy();
+            const auto& transform = pointsToAdvect->transform();
+
+            advectPoints(*pointsToAdvect, *velocity, integrationOrder, timeStep, steps,
+                advectFilter, filter, false);
+
+            CPPUNIT_ASSERT_EQUAL(Index64(3), pointCount(pointsToAdvect->tree()));
+
+            for (auto leaf = pointsToAdvect->tree().beginLeaf(); leaf; ++leaf) {
+                AttributeHandle<Vec3s> positionHandle(leaf->constAttributeArray("P"));
+                AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+                for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+                    int id = idHandle.get(*iter);
+                    Vec3s position = transform.indexToWorld(
+                        positionHandle.get(*iter) + iter.getCoord().asVec3d());
+                    Vec3s expectedPosition(positions[id]);
+                    if (id == 1)    expectedPosition += velocityBackground;
+                    CPPUNIT_ASSERT(math::isApproxEqual(position, expectedPosition, tolerance));
+                }
+            }
+
+            advectIncludeGroups.clear();
+            excludeGroups.clear();
+        }
+    }
+}
+
+
+void TestPointAdvect::testZalesaksDisk()
+{
+    // advect a notched sphere known as Zalesak's disk in a rotational velocity field
+
+    // build the level set sphere
+
+    Vec3s center(0, 0, 0);
+    float radius(10);
+    float voxelSize(0.2);
+
+    auto zalesak = tools::createLevelSetSphere<FloatGrid>(radius, center, voxelSize);
+
+    // create box for notch using width and depth relative to radius
+
+    const math::Transform::Ptr xform = math::Transform::createLinearTransform(voxelSize);
+
+    Vec3f min(center);
+    Vec3f max(center);
+    float notchWidth = 0.5f;
+    float notchDepth = 1.5f;
+
+    min.x() -= (radius * notchWidth) / 2;
+    min.y() -= (radius * (notchDepth - 1));
+    min.z() -= radius * 1.1;
+
+    max.x() += (radius * notchWidth) / 2;
+    max.y() += radius * 1.1;
+    max.z() += radius * 1.1;
+
+    math::BBox<Vec3f> bbox(min, max);
+
+    auto notch = tools::createLevelSetBox<FloatGrid>(bbox, *xform);
+
+    // subtract notch from the sphere
+
+    tools::csgDifference(*zalesak, *notch);
+
+    // scatter points inside the sphere
+
+    auto points = points::denseUniformPointScatter(*zalesak, /*pointsPerVoxel=*/8);
+
+    // append an integer "id" attribute
+
+    auto idAttributeType = TypedAttributeArray<int>::attributeType();
+    appendAttribute(points->tree(), "id", idAttributeType);
+
+    // populate it in serial based on iteration order
+
+    int id = 0;
+    for (auto leaf = points->tree().beginLeaf(); leaf; ++leaf) {
+        AttributeWriteHandle<int> handle(leaf->attributeArray("id"));
+        for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+            handle.set(*iter, id++);
+        }
+    }
+
+    // copy grid into new grid for advecting
+
+    auto pointsToAdvect = points->deepCopy();
+
+    // populate a velocity grid that rotates in X
+
+    auto velocity = Vec3SGrid::create(Vec3s(0));
+    velocity->setTransform(xform);
+
+    CoordBBox activeBbox(zalesak->evalActiveVoxelBoundingBox());
+    activeBbox.expand(5);
+
+    velocity->denseFill(activeBbox, Vec3s(0));
+
+    for (auto leaf = velocity->tree().beginLeaf(); leaf; ++leaf) {
+        for (auto iter = leaf->beginValueOn(); iter; ++iter) {
+            Vec3s position = xform->indexToWorld(iter.getCoord().asVec3d());
+            Vec3s velocity = (position.cross(Vec3s(0, 0, 1)) * 2 * M_PI) / 10;
+            iter.setValue(velocity);
+        }
+    }
+
+    // extract original positions
+
+    const Index count(pointCount(points->constTree()));
+
+    std::vector<Vec3f> preAdvectPositions(count, Vec3f(0));
+
+    for (auto leaf = points->constTree().cbeginLeaf(); leaf; ++leaf) {
+        AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+        AttributeHandle<Vec3f> posHandle(leaf->constAttributeArray("P"));
+        for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+            Vec3f position = posHandle.get(*iter) + iter.getCoord().asVec3d();
+            preAdvectPositions[idHandle.get(*iter)] = xform->indexToWorld(position);
+        }
+    }
+
+    // advect points a half revolution
+
+    points::advectPoints(*pointsToAdvect, *velocity, Index(4), 1.0, 5);
+
+    // extract new positions
+
+    std::vector<Vec3f> postAdvectPositions(count, Vec3f(0));
+
+    for (auto leaf = pointsToAdvect->constTree().cbeginLeaf(); leaf; ++leaf) {
+        AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+        AttributeHandle<Vec3f> posHandle(leaf->constAttributeArray("P"));
+        for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+            Vec3f position = posHandle.get(*iter) + iter.getCoord().asVec3d();
+            postAdvectPositions[idHandle.get(*iter)] = xform->indexToWorld(position);
+        }
+    }
+
+    for (Index i = 0; i < count; i++) {
+        CPPUNIT_ASSERT(!math::isApproxEqual(preAdvectPositions[i], postAdvectPositions[i], Vec3f(0.1)));
+    }
+
+    // advect points another half revolution
+
+    points::advectPoints(*pointsToAdvect, *velocity, Index(4), 1.0, 5);
+
+    for (auto leaf = pointsToAdvect->constTree().cbeginLeaf(); leaf; ++leaf) {
+        AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+        AttributeHandle<Vec3f> posHandle(leaf->constAttributeArray("P"));
+        for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+            Vec3f position = posHandle.get(*iter) + iter.getCoord().asVec3d();
+            postAdvectPositions[idHandle.get(*iter)] = xform->indexToWorld(position);
+        }
+    }
+
+    for (Index i = 0; i < count; i++) {
+        CPPUNIT_ASSERT(math::isApproxEqual(preAdvectPositions[i], postAdvectPositions[i], Vec3f(0.1)));
+    }
+}
+
+
+// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )

--- a/openvdb/unittest/TestPointMask.cc
+++ b/openvdb/unittest/TestPointMask.cc
@@ -51,9 +51,11 @@ public:
 
     CPPUNIT_TEST_SUITE(TestPointMask);
     CPPUNIT_TEST(testMask);
+    CPPUNIT_TEST(testMaskDeformer);
     CPPUNIT_TEST_SUITE_END();
 
     void testMask();
+    void testMaskDeformer();
 
 }; // class TestPointMask
 
@@ -148,6 +150,230 @@ TestPointMask::testMask()
         mask = convertPointsToMask(*points, *newTransform, filter2);
 
         CPPUNIT_ASSERT_EQUAL(mask->tree().activeVoxelCount(), Index64(2));
+    }
+}
+
+
+struct StaticVoxelDeformer
+{
+    StaticVoxelDeformer(const Vec3d& position)
+        : mPosition(position) { }
+
+    template <typename LeafT>
+    void reset(LeafT& /*leaf*/, size_t /*idx*/) { }
+
+    template <typename IterT>
+    void apply(Vec3d& position, IterT&) const { position = mPosition; }
+
+private:
+    Vec3d mPosition;
+};
+
+template <bool WorldSpace = true>
+struct YOffsetDeformer
+{
+    YOffsetDeformer(const Vec3d& offset) : mOffset(offset) { }
+
+    template <typename LeafT>
+    void reset(LeafT& /*leaf*/, size_t /*idx*/) { }
+
+    template <typename IterT>
+    void apply(Vec3d& position, IterT&) const { position += mOffset; }
+
+    Vec3d mOffset;
+};
+
+namespace openvdb {
+OPENVDB_USE_VERSION_NAMESPACE
+namespace OPENVDB_VERSION_NAME {
+namespace points {
+
+// configure both voxel deformers to be applied in index-space
+
+template<>
+struct DeformerTraits<StaticVoxelDeformer> {
+    static const bool IndexSpace = true;
+};
+
+template<>
+struct DeformerTraits<YOffsetDeformer<false>> {
+    static const bool IndexSpace = true;
+};
+
+} // namespace points
+} // namespace OPENVDB_VERSION_NAME
+} // namespace openvdb
+
+
+void
+TestPointMask::testMaskDeformer()
+{
+    // This test validates internal functionality that is used in various applications, such as
+    // building masks and producing count grids. Note that by convention, methods that live
+    // in an "internal" namespace are typically not promoted as part of the public API
+    // and thus do not receive the same level of rigour in avoiding breaking API changes.
+
+    std::vector<Vec3s> positions =  {
+                                        {1, 1, 1},
+                                        {1, 5, 1},
+                                        {2, 1, 1},
+                                        {2, 2, 1},
+                                    };
+
+    const PointAttributeVector<Vec3s> pointList(positions);
+
+    const float voxelSize = 0.1f;
+    openvdb::math::Transform::Ptr transform(
+        openvdb::math::Transform::createLinearTransform(voxelSize));
+
+    tools::PointIndexGrid::Ptr pointIndexGrid =
+        tools::createPointIndexGrid<tools::PointIndexGrid>(pointList, *transform);
+
+    PointDataGrid::Ptr points =
+            createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid,
+                                                          pointList, *transform);
+
+    // assign point 3 to new group "test"
+
+    appendGroup(points->tree(), "test");
+
+    std::vector<short> groups{0,0,1,0};
+
+    setGroup(points->tree(), pointIndexGrid->tree(), groups, "test");
+
+    NullFilter nullFilter;
+
+    { // null deformer
+        NullDeformer deformer;
+
+        auto mask = point_mask_internal::convertPointsToScalar<MaskGrid>(
+            *points, *transform, nullFilter, deformer);
+
+        auto mask2 = convertPointsToMask(*points);
+
+        CPPUNIT_ASSERT_EQUAL(points->tree().activeVoxelCount(), Index64(4));
+        CPPUNIT_ASSERT_EQUAL(mask->tree().activeVoxelCount(), Index64(4));
+        CPPUNIT_ASSERT(mask->tree().hasSameTopology(mask2->tree()));
+        CPPUNIT_ASSERT(mask->tree().hasSameTopology(points->tree()));
+    }
+
+    { // static voxel deformer
+        // collapse all points into a random voxel at (9, 13, 106)
+        StaticVoxelDeformer deformer(Vec3d(9, 13, 106));
+
+        auto mask = point_mask_internal::convertPointsToScalar<MaskGrid>(
+            *points, *transform, nullFilter, deformer);
+
+        CPPUNIT_ASSERT_EQUAL(mask->tree().activeVoxelCount(), Index64(1));
+        CPPUNIT_ASSERT(!mask->tree().cbeginLeaf()->isValueOn(Coord(9, 13, 105)));
+        CPPUNIT_ASSERT(mask->tree().cbeginLeaf()->isValueOn(Coord(9, 13, 106)));
+    }
+
+    { // +y offset deformer
+        Vec3d offset(0, 41.7, 0);
+        YOffsetDeformer</*world-space*/false> deformer(offset);
+
+        auto mask = point_mask_internal::convertPointsToScalar<MaskGrid>(
+            *points, *transform, nullFilter, deformer);
+
+        // (repeat with deformer configured as world-space)
+        YOffsetDeformer</*world-space*/true> deformerWS(offset * voxelSize);
+
+        auto maskWS = point_mask_internal::convertPointsToScalar<MaskGrid>(
+            *points, *transform, nullFilter, deformerWS);
+
+        CPPUNIT_ASSERT_EQUAL(mask->tree().activeVoxelCount(), Index64(4));
+        CPPUNIT_ASSERT_EQUAL(maskWS->tree().activeVoxelCount(), Index64(4));
+
+        std::vector<Coord> maskVoxels;
+        std::vector<Coord> maskVoxelsWS;
+        std::vector<Coord> pointVoxels;
+
+        for (auto leaf = mask->tree().cbeginLeaf(); leaf; ++leaf) {
+            for (auto iter = leaf->cbeginValueOn(); iter; ++iter) {
+                maskVoxels.emplace_back(iter.getCoord());
+            }
+        }
+
+        for (auto leaf = maskWS->tree().cbeginLeaf(); leaf; ++leaf) {
+            for (auto iter = leaf->cbeginValueOn(); iter; ++iter) {
+                maskVoxelsWS.emplace_back(iter.getCoord());
+            }
+        }
+
+        for (auto leaf = points->tree().cbeginLeaf(); leaf; ++leaf) {
+            for (auto iter = leaf->cbeginValueOn(); iter; ++iter) {
+                pointVoxels.emplace_back(iter.getCoord());
+            }
+        }
+
+        std::sort(maskVoxels.begin(), maskVoxels.end());
+        std::sort(maskVoxelsWS.begin(), maskVoxelsWS.end());
+        std::sort(pointVoxels.begin(), pointVoxels.end());
+
+        CPPUNIT_ASSERT_EQUAL(maskVoxels.size(), size_t(4));
+        CPPUNIT_ASSERT_EQUAL(maskVoxelsWS.size(), size_t(4));
+        CPPUNIT_ASSERT_EQUAL(pointVoxels.size(), size_t(4));
+
+        for (int i = 0; i < int(pointVoxels.size()); i++) {
+            Coord newCoord(pointVoxels[i]);
+            newCoord.x() = (newCoord.x() + offset.x());
+            newCoord.y() = math::Round((newCoord.y() + offset.y()));
+            newCoord.z() = (newCoord.z() + offset.z());
+            CPPUNIT_ASSERT_EQUAL(maskVoxels[i], newCoord);
+            CPPUNIT_ASSERT_EQUAL(maskVoxelsWS[i], newCoord);
+        }
+
+        // use a different transform to verify deformers and transforms can be used together
+
+        const float newVoxelSize = 0.02f;
+        openvdb::math::Transform::Ptr newTransform(
+            openvdb::math::Transform::createLinearTransform(newVoxelSize));
+
+        auto mask2 = point_mask_internal::convertPointsToScalar<MaskGrid>(
+            *points, *newTransform, nullFilter, deformer);
+
+        CPPUNIT_ASSERT_EQUAL(mask2->tree().activeVoxelCount(), Index64(4));
+
+        std::vector<Coord> maskVoxels2;
+
+        for (auto leaf = mask2->tree().cbeginLeaf(); leaf; ++leaf) {
+            for (auto iter = leaf->cbeginValueOn(); iter; ++iter) {
+                maskVoxels2.emplace_back(iter.getCoord());
+            }
+        }
+
+        std::sort(maskVoxels2.begin(), maskVoxels2.end());
+
+        for (int i = 0; i < int(maskVoxels.size()); i++) {
+            Coord newCoord(pointVoxels[i]);
+            newCoord.x() = (newCoord.x() + offset.x()) * 5;
+            newCoord.y() = math::Round((newCoord.y() + offset.y()) * 5);
+            newCoord.z() = (newCoord.z() + offset.z()) * 5;
+            CPPUNIT_ASSERT_EQUAL(maskVoxels2[i], newCoord);
+        }
+
+        // only use points in group "test"
+
+        std::vector<std::string> includeGroups{"test"};
+        std::vector<std::string> excludeGroups;
+        MultiGroupFilter filter(includeGroups, excludeGroups,
+            points->tree().cbeginLeaf()->attributeSet());
+
+        auto mask3 = point_mask_internal::convertPointsToScalar<MaskGrid>(
+            *points, *transform, filter, deformer);
+
+        CPPUNIT_ASSERT_EQUAL(mask3->tree().activeVoxelCount(), Index64(1));
+
+        for (auto leaf = mask3->tree().cbeginLeaf(); leaf; ++leaf) {
+            for (auto iter = leaf->cbeginValueOn(); iter; ++iter) {
+                Coord newCoord(pointVoxels[2]);
+                newCoord.x() = (newCoord.x() + offset.x());
+                newCoord.y() = math::Round((newCoord.y() + offset.y()));
+                newCoord.z() = (newCoord.z() + offset.z());
+                CPPUNIT_ASSERT_EQUAL(iter.getCoord(), newCoord);
+            }
+        }
     }
 }
 

--- a/openvdb/unittest/TestPointMove.cc
+++ b/openvdb/unittest/TestPointMove.cc
@@ -1,0 +1,1128 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2012-2018 DreamWorks Animation LLC
+//
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+//
+// Redistributions of source code must retain the above copyright
+// and license notice and the following restrictions and disclaimer.
+//
+// *     Neither the name of DreamWorks Animation nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+// LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+//
+///////////////////////////////////////////////////////////////////////////
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <openvdb/unittest/util.h>
+#include <openvdb/points/PointAttribute.h>
+#include <openvdb/points/PointDataGrid.h>
+#include <openvdb/points/PointConversion.h>
+#include <openvdb/points/PointMove.h>
+#include <openvdb/openvdb.h>
+
+#include <openvdb/Types.h>
+
+#include <tbb/atomic.h>
+
+using namespace openvdb;
+using namespace openvdb::points;
+
+class TestPointMove: public CppUnit::TestCase
+{
+public:
+
+    void setUp() override { openvdb::initialize(); }
+    void tearDown() override { openvdb::uninitialize(); }
+
+    CPPUNIT_TEST_SUITE(TestPointMove);
+    CPPUNIT_TEST(testCachedDeformer);
+    CPPUNIT_TEST(testMoveLocal);
+    CPPUNIT_TEST(testMoveGlobal);
+    CPPUNIT_TEST(testCustomDeformer);
+    CPPUNIT_TEST(testPointData);
+    CPPUNIT_TEST_SUITE_END();
+
+    void testCachedDeformer();
+    void testMoveLocal();
+    void testMoveGlobal();
+    void testCustomDeformer();
+    void testPointData();
+}; // class TestPointMove
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestPointMove);
+
+
+////////////////////////////////////////
+
+
+namespace {
+
+struct OffsetDeformer
+{
+    OffsetDeformer(const Vec3d& _offset)
+        : offset(_offset){ }
+
+    template <typename LeafT>
+    void reset(const LeafT&, size_t /*idx*/) { }
+
+    template <typename IndexIterT>
+    void apply(Vec3d& position, const IndexIterT&) const
+    {
+        position += offset;
+    }
+
+    Vec3d offset;
+}; // struct OffsetDeformer
+
+template <typename FilterT>
+struct OffsetFilteredDeformer
+{
+    OffsetFilteredDeformer(const Vec3d& _offset,
+                    const FilterT& _filter)
+        : offset(_offset)
+        , filter(_filter) { }
+
+    template <typename LeafT>
+    void reset(const LeafT& leaf, size_t /*idx*/)
+    {
+        filter.template reset(leaf);
+    }
+
+    template <typename IndexIterT>
+    void apply(Vec3d& position, const IndexIterT& iter) const
+    {
+        if (!filter.template valid(iter))    return;
+        position += offset;
+    }
+
+    void finalize() const { }
+
+    Vec3d offset;
+    FilterT filter;
+}; // struct OffsetFilteredDeformer
+
+
+PointDataGrid::Ptr positionsToGrid(const std::vector<Vec3s>& positions,
+                                   const float voxelSize = 1.0)
+{
+    const PointAttributeVector<Vec3s> pointList(positions);
+
+    openvdb::math::Transform::Ptr transform(
+        openvdb::math::Transform::createLinearTransform(voxelSize));
+
+    tools::PointIndexGrid::Ptr pointIndexGrid =
+        tools::createPointIndexGrid<tools::PointIndexGrid>(pointList, *transform);
+
+    PointDataGrid::Ptr points =
+            createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid,
+                                                          pointList, *transform);
+
+    // assign point 3 to new group "test" if more than 3 points
+
+    if (positions.size() > 3) {
+        appendGroup(points->tree(), "test");
+
+        std::vector<short> groups(positions.size(), 0);
+        groups[2] = 1;
+
+        setGroup(points->tree(), pointIndexGrid->tree(), groups, "test");
+    }
+
+    return points;
+}
+
+
+std::vector<Vec3s> gridToPositions(const PointDataGrid::Ptr& points, bool sort = true)
+{
+    std::vector<Vec3s> positions;
+
+    for (auto leaf = points->tree().beginLeaf(); leaf; ++leaf) {
+
+        const openvdb::points::AttributeArray& positionArray =
+            leaf->constAttributeArray("P");
+        openvdb::points::AttributeHandle<openvdb::Vec3f> positionHandle(positionArray);
+
+        for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+            openvdb::Vec3f voxelPosition = positionHandle.get(*iter);
+            openvdb::Vec3d xyz = iter.getCoord().asVec3d();
+            openvdb::Vec3f worldPosition = points->transform().indexToWorld(voxelPosition + xyz);
+
+            positions.push_back(worldPosition);
+        }
+    }
+
+    if (sort)   std::sort(positions.begin(), positions.end());
+    return positions;
+}
+
+
+std::vector<Vec3s> applyOffset(const std::vector<Vec3s>& positions, const Vec3s& offset)
+{
+    std::vector<Vec3s> newPositions;
+
+    for (const auto& it : positions) {
+        newPositions.emplace_back(it + offset);
+    }
+
+    std::sort(newPositions.begin(), newPositions.end());
+    return newPositions;
+}
+
+
+template<typename T>
+inline void
+ASSERT_APPROX_EQUAL(const std::vector<T>& a, const std::vector<T>& b,
+                    const Index lineNumber, const double tolerance = 1e-6)
+{
+    std::stringstream ss;
+    ss << "Assertion Line Number: " << lineNumber;
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(ss.str(), a.size(), b.size());
+
+    for (int i = 0; i < a.size(); i++) {
+        CPPUNIT_ASSERT_MESSAGE(ss.str(), math::isApproxEqual(a[i], b[i]));
+    }
+}
+
+
+template<typename T>
+inline void
+ASSERT_APPROX_EQUAL(const std::vector<math::Vec3<T>>& a, const std::vector<math::Vec3<T>>& b,
+                    const Index lineNumber, const double tolerance = 1e-6)
+{
+    std::stringstream ss;
+    ss << "Assertion Line Number: " << lineNumber;
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(ss.str(), a.size(), b.size());
+
+    for (int i = 0; i < a.size(); i++) {
+        CPPUNIT_ASSERT_MESSAGE(ss.str(), math::isApproxEqual(a[i], b[i]));
+    }
+}
+
+struct NullObject { };
+
+// A dummy iterator that can be used to match LeafIter and IndexIter interfaces
+struct DummyIter
+{
+    DummyIter(Index _index): index(_index) { }
+    Index pos() const { return index; }
+    Index operator*() const { return index; }
+    Index index;
+};
+
+struct OddIndexFilter
+{
+    static bool initialized() { return true; }
+    static index::State state() { return index::PARTIAL; }
+    template <typename LeafT>
+    static index::State state(const LeafT& leaf) { return index::PARTIAL; }
+
+    template <typename LeafT>
+    void reset(const LeafT&) { }
+    template <typename IterT>
+    bool valid(const IterT& iter) const {
+        return ((*iter) % 2) == 1;
+    }
+};
+
+} // namespace
+
+
+void
+TestPointMove::testCachedDeformer()
+{
+    NullObject nullObject;
+
+    // create an empty cache and CachedDeformer
+    CachedDeformer<double>::Cache cache;
+    CPPUNIT_ASSERT(cache.leafs.empty());
+
+    CachedDeformer<double> cachedDeformer(cache);
+
+    // check initialization is as expected
+    CPPUNIT_ASSERT(cachedDeformer.mLocalLeafVec.empty());
+    CPPUNIT_ASSERT(cachedDeformer.mLeafVec == nullptr);
+    CPPUNIT_ASSERT(cachedDeformer.mLeafMap == nullptr);
+
+    // throw when resetting cachedDeformer with an empty cache
+    CPPUNIT_ASSERT_THROW(cachedDeformer.reset(nullObject, size_t(0)), openvdb::IndexError);
+
+    // manually create one leaf in the cache
+    cache.leafs.resize(1);
+    auto& leaf = cache.leafs[0];
+    CPPUNIT_ASSERT(leaf.vecData.empty());
+    CPPUNIT_ASSERT(leaf.mapData.empty());
+    CPPUNIT_ASSERT_EQUAL(Index(0), leaf.totalSize);
+
+    // reset should no longer throw and leaf vec pointer should now be non-null
+    CPPUNIT_ASSERT_NO_THROW(cachedDeformer.reset(nullObject, size_t(0)));
+    CPPUNIT_ASSERT(cachedDeformer.mLocalLeafVec.empty());
+    CPPUNIT_ASSERT(cachedDeformer.mLeafMap == nullptr);
+    CPPUNIT_ASSERT(cachedDeformer.mLeafVec != nullptr);
+    CPPUNIT_ASSERT(cachedDeformer.mLeafVec->empty());
+
+    // nothing stored in the cache so position is unchanged
+    DummyIter indexIter(0);
+    Vec3d position(0,0,0);
+    Vec3d newPosition(position);
+    cachedDeformer.apply(newPosition, indexIter);
+    CPPUNIT_ASSERT(math::isApproxEqual(position, newPosition));
+
+    // insert a new value into the leaf vector and verify tbe position is deformed
+    Vec3d deformedPosition(5,10,15);
+    leaf.vecData.push_back(deformedPosition);
+    cachedDeformer.apply(newPosition, indexIter);
+    CPPUNIT_ASSERT(math::isApproxEqual(deformedPosition, newPosition));
+
+    // insert a new value into the leaf map and verify the position is deformed as before
+    Vec3d newDeformedPosition(2,3,4);
+    leaf.mapData.insert({0, newDeformedPosition});
+    newPosition.setZero();
+    cachedDeformer.apply(newPosition, indexIter);
+    CPPUNIT_ASSERT(math::isApproxEqual(deformedPosition, newPosition));
+
+    // now reset the cached deformer and verify the value is updated
+    // (map has precedence over vector)
+    cachedDeformer.reset(nullObject, size_t(0));
+    CPPUNIT_ASSERT(cachedDeformer.mLocalLeafVec.empty());
+    CPPUNIT_ASSERT(cachedDeformer.mLeafMap != nullptr);
+    CPPUNIT_ASSERT(cachedDeformer.mLeafVec == nullptr);
+    newPosition.setZero();
+    cachedDeformer.apply(newPosition, indexIter);
+    CPPUNIT_ASSERT(math::isApproxEqual(newDeformedPosition, newPosition));
+
+    // test map -> vector expansion
+    leaf.mapData.clear();
+    for (int i = 0; i < 16; i++) {
+        leaf.mapData.insert({i, Vec3d(0, i, 0)});
+    }
+
+    cachedDeformer.reset(nullObject, size_t(0));
+
+    // 16 values (or less) so local vector is not populated
+    CPPUNIT_ASSERT(cachedDeformer.mLocalLeafVec.empty());
+    CPPUNIT_ASSERT(cachedDeformer.mLeafMap != nullptr);
+    CPPUNIT_ASSERT(cachedDeformer.mLeafVec == nullptr);
+
+    // check value access
+    for (int i = 0; i < 16; i++) {
+        DummyIter indexIterI(i);
+        cachedDeformer.apply(newPosition, indexIterI);
+        CPPUNIT_ASSERT(math::isApproxEqual(Vec3d(0, i, 0), newPosition));
+    }
+
+    leaf.mapData.insert({16, Vec3d(0, 16, 0)});
+
+    // ValueError thrown because totalSize has not been set correctly
+    CPPUNIT_ASSERT_THROW(cachedDeformer.reset(nullObject, size_t(0)), openvdb::ValueError);
+
+    // use very large total size to prevent local expansion
+    leaf.totalSize = 17 * 256 + 1;
+
+    CPPUNIT_ASSERT_NO_THROW(cachedDeformer.reset(nullObject, size_t(0)));
+
+    CPPUNIT_ASSERT(cachedDeformer.mLocalLeafVec.empty());
+    CPPUNIT_ASSERT(cachedDeformer.mLeafMap != nullptr);
+    CPPUNIT_ASSERT(cachedDeformer.mLeafVec == nullptr);
+
+    // use total size that represents a sequential dataset
+    leaf.totalSize = leaf.mapData.size();
+
+    CPPUNIT_ASSERT_NO_THROW(cachedDeformer.reset(nullObject, size_t(0)));
+
+    // greater than 16 values so local vector is populated
+    CPPUNIT_ASSERT_EQUAL(leaf.mapData.size(), cachedDeformer.mLocalLeafVec.size());
+    CPPUNIT_ASSERT(cachedDeformer.mLeafMap == nullptr);
+    CPPUNIT_ASSERT(cachedDeformer.mLeafVec != nullptr);
+
+    // check value access
+    for (int i = 0; i < 17; i++) {
+        DummyIter indexIterI(i);
+        cachedDeformer.apply(newPosition, indexIterI);
+        CPPUNIT_ASSERT(math::isApproxEqual(Vec3d(0, i, 0), newPosition));
+    }
+
+    // four points, some same leaf, some different
+    const float voxelSize = 1.0f;
+    std::vector<Vec3s> positions =  {
+                                        {5, 2, 3},
+                                        {2, 4, 1},
+                                        {50, 5, 1},
+                                        {3, 20, 1},
+                                    };
+
+    PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+    // evaluate with null deformer and no filter
+
+    NullDeformer nullDeformer;
+    NullFilter nullFilter;
+    cachedDeformer.evaluate(*points, nullDeformer, nullFilter);
+
+    CPPUNIT_ASSERT_EQUAL(size_t(points->tree().leafCount()), cache.leafs.size());
+
+    int leafIndex = 0;
+    for (auto leaf = points->tree().cbeginLeaf(); leaf; ++leaf) {
+        for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+            AttributeHandle<Vec3f> handle(leaf->constAttributeArray("P"));
+            Vec3f position(handle.get(*iter) + iter.getCoord());
+            Vec3f cachePosition = cache.leafs[leafIndex].vecData[*iter];
+            CPPUNIT_ASSERT(math::isApproxEqual(position, cachePosition));
+        }
+        leafIndex++;
+    }
+
+    // evaluate with Offset deformer and no filter
+
+    Vec3d yOffset(1,2,3);
+    OffsetDeformer yOffsetDeformer(yOffset);
+
+    cachedDeformer.evaluate(*points, yOffsetDeformer, nullFilter);
+
+    CPPUNIT_ASSERT_EQUAL(size_t(points->tree().leafCount()), cache.leafs.size());
+
+    leafIndex = 0;
+    for (auto leaf = points->tree().cbeginLeaf(); leaf; ++leaf) {
+        for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+            AttributeHandle<Vec3f> handle(leaf->constAttributeArray("P"));
+            Vec3f position(handle.get(*iter) + iter.getCoord() + yOffset);
+            Vec3f cachePosition = cache.leafs[leafIndex].vecData[*iter];
+            CPPUNIT_ASSERT(math::isApproxEqual(position, cachePosition));
+        }
+        leafIndex++;
+    }
+
+    // evaluate with Offset deformer and OddIndex filter
+
+    OddIndexFilter oddFilter;
+    cachedDeformer.evaluate(*points, yOffsetDeformer, oddFilter);
+
+    CPPUNIT_ASSERT_EQUAL(size_t(points->tree().leafCount()), cache.leafs.size());
+
+    leafIndex = 0;
+    for (auto leaf = points->tree().cbeginLeaf(); leaf; ++leaf) {
+        for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+            AttributeHandle<Vec3f> handle(leaf->constAttributeArray("P"));
+            Vec3f position(handle.get(*iter) + iter.getCoord() + yOffset);
+            Vec3f cachePosition = cache.leafs[leafIndex].vecData[*iter];
+            CPPUNIT_ASSERT(math::isApproxEqual(position, cachePosition));
+        }
+        leafIndex++;
+    }
+}
+
+
+void
+TestPointMove::testMoveLocal()
+{
+    // This test is for points that only move locally, meaning that
+    // they remain in the leaf from which they originated
+
+    { // single point, y offset, same voxel
+        const float voxelSize = 1.0f;
+        Vec3d offset(0, 0.1, 0);
+        OffsetDeformer deformer(offset);
+
+        std::vector<Vec3s> positions =          {
+                                                    {10, 10, 10},
+                                                };
+
+        std::vector<Vec3s> desiredPositions = applyOffset(positions, offset);
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        movePoints(*points, deformer);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+
+    { // two points, y offset, same voxel
+        const float voxelSize = 1.0f;
+        Vec3d offset(0, 0.1, 0);
+        OffsetDeformer deformer(offset);
+
+        std::vector<Vec3s> positions =          {
+                                                    {10, 10, 10},
+                                                    {10, 10.1, 10},
+                                                };
+
+        std::vector<Vec3s> desiredPositions = applyOffset(positions, offset);
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        movePoints(*points, deformer);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+
+    { // two points, y offset, different voxels
+        const float voxelSize = 1.0f;
+        Vec3d offset(0, 0.1, 0);
+        OffsetDeformer deformer(offset);
+
+        std::vector<Vec3s> positions =          {
+                                                    {10, 10, 10},
+                                                    {10, 11, 10},
+                                                };
+
+        std::vector<Vec3s> desiredPositions = applyOffset(positions, offset);
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        movePoints(*points, deformer);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+
+    { // four points, y offset, same voxel, only third point is kept
+        const float voxelSize = 1.0f;
+        Vec3d offset(0, 0.1, 0);
+        OffsetDeformer deformer(offset);
+
+        std::vector<Vec3s> positions =          {
+                                                    {10, 10, 10},
+                                                    {10, 10.1, 10},
+                                                    {10, 10.2, 10},
+                                                    {10, 10.3, 10},
+                                                };
+
+        std::vector<Vec3s> desiredPositions;
+        desiredPositions.emplace_back(positions[2]+offset);
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        std::vector<std::string> includeGroups{"test"};
+        std::vector<std::string> excludeGroups;
+
+        auto leaf = points->tree().cbeginLeaf();
+        MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+        movePoints(*points, deformer, filter);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+
+    { // four points, y offset, different voxels, only third point is kept
+        const float voxelSize = 1.0f;
+        Vec3d offset(0, 0.1, 0);
+        OffsetDeformer deformer(offset);
+
+        std::vector<Vec3s> positions =          {
+                                                    {10, 10, 10},
+                                                    {10, 11, 10},
+                                                    {10, 12, 10},
+                                                    {10, 13, 10},
+                                                };
+
+        std::vector<Vec3s> desiredPositions;
+        desiredPositions.emplace_back(positions[2]+offset);
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        std::vector<std::string> includeGroups{"test"};
+        std::vector<std::string> excludeGroups;
+
+        auto leaf = points->tree().cbeginLeaf();
+        MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+        movePoints(*points, deformer, filter);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+
+    { // four points, y offset, different voxels, only third point is moved
+        const float voxelSize = 1.0f;
+        Vec3d offset(0, 0.1, 0);
+
+        std::vector<Vec3s> positions =          {
+                                                    {10, 10, 10},
+                                                    {10, 11, 10},
+                                                    {10, 12, 10},
+                                                    {10, 13, 10},
+                                                };
+
+        std::vector<Vec3s> desiredPositions(positions);
+        desiredPositions[2] = positions[2] + offset;
+
+        std::sort(desiredPositions.begin(), desiredPositions.end());
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        std::vector<std::string> includeGroups{"test"};
+        std::vector<std::string> excludeGroups;
+
+        auto leaf = points->tree().cbeginLeaf();
+        MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+        OffsetFilteredDeformer<MultiGroupFilter> deformer(offset, filter);
+        movePoints(*points, deformer);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+}
+
+
+void
+TestPointMove::testMoveGlobal()
+{
+    { // four points, all different leafs
+        const float voxelSize = 0.1f;
+        Vec3d offset(0, 10.1, 0);
+        OffsetDeformer deformer(offset);
+
+        std::vector<Vec3s> positions =          {
+                                                    {1, 1, 1},
+                                                    {1, 5.05, 1},
+                                                    {2, 1, 1},
+                                                    {2, 2, 1},
+                                                };
+
+        std::vector<Vec3s> desiredPositions = applyOffset(positions, offset);
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        movePoints(*points, deformer);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+
+    { // four points, all different leafs, only third point is kept
+        const float voxelSize = 0.1f;
+        Vec3d offset(0, 10.1, 0);
+        OffsetDeformer deformer(offset);
+
+        std::vector<Vec3s> positions =          {
+                                                    {1, 1, 1},
+                                                    {1, 5.05, 1},
+                                                    {2, 1, 1},
+                                                    {2, 2, 1},
+                                                };
+
+        std::vector<Vec3s> desiredPositions;
+        desiredPositions.emplace_back(positions[2]+offset);
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        std::vector<std::string> includeGroups{"test"};
+        std::vector<std::string> excludeGroups;
+
+        auto leaf = points->tree().cbeginLeaf();
+        MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+        movePoints(*points, deformer, filter);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+
+    { // four points, all different leafs, third point is deleted
+        const float voxelSize = 0.1f;
+        Vec3d offset(0, 10.1, 0);
+        OffsetDeformer deformer(offset);
+
+        std::vector<Vec3s> positions =          {
+                                                    {1, 1, 1},
+                                                    {1, 5.05, 1},
+                                                    {2, 1, 1},
+                                                    {2, 2, 1},
+                                                };
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        std::vector<Vec3s> desiredPositions;
+        desiredPositions.emplace_back(positions[0]+offset);
+        desiredPositions.emplace_back(positions[1]+offset);
+        desiredPositions.emplace_back(positions[3]+offset);
+
+        std::vector<std::string> includeGroups;
+        std::vector<std::string> excludeGroups{"test"};
+
+        auto leaf = points->tree().cbeginLeaf();
+        MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+        movePoints(*points, deformer, filter);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+
+    { // six points, some same leaf, some different
+        const float voxelSize = 1.0f;
+        Vec3d offset(0, 0.1, 0);
+        OffsetDeformer deformer(offset);
+
+        std::vector<Vec3s> positions =          {
+                                                    {1, 1, 1},
+                                                    {1.01,1.01,1.01},
+                                                    {1, 5.05, 1},
+                                                    {2, 1, 1},
+                                                    {2.01,1.01,1.01},
+                                                    {2, 2, 1},
+                                                };
+
+        std::vector<Vec3s> desiredPositions = applyOffset(positions, offset);
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        movePoints(*points, deformer);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+
+    { // four points, all different leafs, only third point is moved
+        const float voxelSize = 0.1f;
+        Vec3d offset(0, 10.1, 0);
+
+        std::vector<Vec3s> positions =          {
+                                                    {1, 1, 1},
+                                                    {1, 5.05, 1},
+                                                    {2, 1, 1},
+                                                    {2, 2, 1},
+                                                };
+
+        std::vector<Vec3s> desiredPositions(positions);
+        desiredPositions[2] = positions[2] + offset;
+
+        std::sort(desiredPositions.begin(), desiredPositions.end());
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        std::vector<std::string> includeGroups{"test"};
+        std::vector<std::string> excludeGroups;
+
+        auto leaf = points->tree().cbeginLeaf();
+        MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+        OffsetFilteredDeformer<MultiGroupFilter> deformer(offset, filter);
+        movePoints(*points, deformer);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+
+    { // four points, all different leafs, only third point is kept but not moved
+        const float voxelSize = 0.1f;
+        Vec3d offset(0, 10.1, 0);
+
+        std::vector<Vec3s> positions =          {
+                                                    {1, 1, 1},
+                                                    {1, 5.05, 1},
+                                                    {2, 1, 1},
+                                                    {2, 2, 1},
+                                                };
+
+        std::vector<Vec3s> desiredPositions;
+        desiredPositions.emplace_back(positions[2]);
+
+        std::sort(desiredPositions.begin(), desiredPositions.end());
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        // these groups mark which points are kept
+
+        std::vector<std::string> includeGroups{"test"};
+        std::vector<std::string> excludeGroups;
+
+        // these groups mark which points are moved
+
+        std::vector<std::string> moveIncludeGroups;
+        std::vector<std::string> moveExcludeGroups{"test"};
+
+        auto leaf = points->tree().cbeginLeaf();
+        MultiGroupFilter moveFilter(moveIncludeGroups, moveExcludeGroups, leaf->attributeSet());
+        MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+        OffsetFilteredDeformer<MultiGroupFilter> deformer(offset, moveFilter);
+        movePoints(*points, deformer, filter);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+    }
+}
+
+
+namespace {
+
+// Custom Deformer with reset and apply counters
+struct CustomDeformer
+{
+    using LeafT = PointDataGrid::TreeType::LeafNodeType;
+
+    CustomDeformer(const openvdb::Vec3d& offset,
+                   tbb::atomic<int>& resetCalls,
+                   tbb::atomic<int>& applyCalls)
+        : mOffset(offset)
+        , mResetCalls(resetCalls)
+        , mApplyCalls(applyCalls) { }
+
+    template <typename LeafT>
+    void reset(const LeafT& /*leaf*/, size_t /*idx*/)
+    {
+        mResetCalls++;
+    }
+
+    template <typename IndexIterT>
+    void apply(Vec3d& position, const IndexIterT&) const
+    {
+        // ensure reset has been called at least once
+        if (mResetCalls > 0) {
+            position += mOffset;
+        }
+        mApplyCalls++;
+    }
+
+    const openvdb::Vec3d mOffset;
+    tbb::atomic<int>& mResetCalls;
+    tbb::atomic<int>& mApplyCalls;
+}; // struct CustomDeformer
+
+// Custom Deformer that always returns the position supplied in the constructor
+struct StaticDeformer
+{
+    StaticDeformer(const openvdb::Vec3d& position)
+        : mPosition(position) { }
+
+    template <typename LeafT>
+    void reset(const LeafT& /*leaf*/, size_t /*idx*/) { }
+
+    template <typename IndexIterT>
+    void apply(Vec3d& position, const IndexIterT&) const
+    {
+        position = mPosition;
+    }
+
+    const openvdb::Vec3d mPosition;
+}; // struct StaticDeformer
+
+} // namespace
+
+void
+TestPointMove::testCustomDeformer()
+{
+    { // four points, some same leaf, some different, custom deformer
+        const float voxelSize = 1.0f;
+        Vec3d offset(4.5,3.2,1.85);
+
+        std::vector<Vec3s> positions =          {
+                                                    {5, 2, 3},
+                                                    {2, 4, 1},
+                                                    {50, 5, 1},
+                                                    {3, 20, 1},
+                                                };
+
+        std::vector<Vec3s> desiredPositions = applyOffset(positions, offset);
+
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+        PointDataGrid::Ptr cachedPoints = points->deepCopy();
+
+        const int leafCount = points->tree().leafCount();
+        const int pointCount = positions.size();
+
+        tbb::atomic<int> resetCalls = 0;
+        tbb::atomic<int> applyCalls = 0;
+
+        // this deformer applies an offset and tracks the number of calls
+
+        CustomDeformer deformer(offset, resetCalls, applyCalls);
+
+        movePoints(*points, deformer);
+
+        CPPUNIT_ASSERT(2*leafCount == resetCalls);
+        CPPUNIT_ASSERT(2*pointCount == applyCalls);
+
+        std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+
+        // use CachedDeformer
+
+        resetCalls = 0;
+        applyCalls = 0;
+
+        CachedDeformer<double>::Cache cache;
+        CachedDeformer<double> cachedDeformer(cache);
+        NullFilter filter;
+        cachedDeformer.evaluate(*cachedPoints, deformer, filter);
+
+        movePoints(*cachedPoints, cachedDeformer);
+
+        CPPUNIT_ASSERT(leafCount == resetCalls);
+        CPPUNIT_ASSERT(pointCount == applyCalls);
+
+        std::vector<Vec3s> cachedPositions = gridToPositions(cachedPoints);
+
+        ASSERT_APPROX_EQUAL(desiredPositions, cachedPositions, __LINE__);
+    }
+
+    {
+        { // four points, some same leaf, some different, static deformer
+            const float voxelSize = 1.0f;
+            Vec3d newPosition(15.2,18.3,-100.9);
+
+            std::vector<Vec3s> positions =          {
+                                                        {5, 2, 3},
+                                                        {2, 4, 1},
+                                                        {50, 5, 1},
+                                                        {3, 20, 1},
+                                                    };
+
+            std::vector<Vec3s> desiredPositions(positions.size(), newPosition);
+
+            PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+            StaticDeformer deformer(newPosition);
+
+            movePoints(*points, deformer);
+
+            std::vector<Vec3s> actualPositions = gridToPositions(points);
+
+            ASSERT_APPROX_EQUAL(desiredPositions, actualPositions, __LINE__);
+        }
+    }
+}
+
+
+namespace {
+
+// Custom deformer that stores a map of current positions to new positions
+struct AssignDeformer
+{
+    AssignDeformer(const std::map<Vec3d, Vec3d>& _values)
+        : values(_values) { }
+
+    template <typename LeafT>
+    void reset(const LeafT&, size_t /*idx*/) { }
+
+    template <typename IndexIterT>
+    void apply(Vec3d& position, const IndexIterT&) const
+    {
+        position = values.at(position);
+    }
+
+    std::map<Vec3d, Vec3d> values;
+}; // struct AssignDeformer
+
+}
+
+
+void
+TestPointMove::testPointData()
+{
+    // four points, some same leaf, some different
+    // spatial order is (1, 0, 3, 2)
+
+    const float voxelSize = 1.0f;
+    std::vector<Vec3s> positions =  {
+                                    {5, 2, 3},
+                                    {2, 4, 1},
+                                    {50, 5, 1},
+                                    {3, 20, 1},
+                                };
+
+    // simple reversing deformer
+
+    std::map<Vec3d, Vec3d> remap;
+    remap.insert({positions[0], positions[3]});
+    remap.insert({positions[1], positions[2]});
+    remap.insert({positions[2], positions[1]});
+    remap.insert({positions[3], positions[0]});
+
+    AssignDeformer deformer(remap);
+
+    { // reversing point positions results in the same iteration order due to spatial organisation
+        PointDataGrid::Ptr points = positionsToGrid(positions, voxelSize);
+
+        std::vector<Vec3s> initialPositions = gridToPositions(points, /*sort=*/false);
+
+        std::vector<std::string> includeGroups;
+        std::vector<std::string> excludeGroups;
+
+        movePoints(*points, deformer);
+
+        std::vector<Vec3s> finalPositions1 = gridToPositions(points, /*sort=*/false);
+
+        ASSERT_APPROX_EQUAL(initialPositions, finalPositions1, __LINE__);
+
+        // now we delete the third point while sorting, using the test group
+
+        excludeGroups.push_back("test");
+
+        auto leaf = points->tree().cbeginLeaf();
+        MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+        movePoints(*points, deformer, filter);
+
+        std::vector<Vec3s> desiredPositions;
+        desiredPositions.emplace_back(positions[0]);
+        desiredPositions.emplace_back(positions[1]);
+        desiredPositions.emplace_back(positions[3]);
+
+        std::vector<Vec3s> finalPositions2 = gridToPositions(points, /*sort=*/false);
+
+        std::sort(desiredPositions.begin(), desiredPositions.end());
+        std::sort(finalPositions2.begin(), finalPositions2.end());
+
+        ASSERT_APPROX_EQUAL(desiredPositions, finalPositions2, __LINE__);
+    }
+
+    { // additional point data - integer "id", float "pscale", "odd" and "even" groups
+
+        std::vector<int> id;
+        id.push_back(0);
+        id.push_back(1);
+        id.push_back(2);
+        id.push_back(3);
+
+        std::vector<float> radius;
+        radius.push_back(0.1);
+        radius.push_back(0.15);
+        radius.push_back(0.2);
+        radius.push_back(0.5);
+
+        // manually construct point data grid instead of using positionsToGrid()
+
+        const PointAttributeVector<Vec3s> pointList(positions);
+
+        openvdb::math::Transform::Ptr transform(
+            openvdb::math::Transform::createLinearTransform(voxelSize));
+
+        tools::PointIndexGrid::Ptr pointIndexGrid =
+            tools::createPointIndexGrid<tools::PointIndexGrid>(pointList, *transform);
+
+        PointDataGrid::Ptr points =
+                createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid,
+                                                              pointList, *transform);
+        auto idAttributeType =
+            openvdb::points::TypedAttributeArray<int>::attributeType();
+        openvdb::points::appendAttribute(points->tree(), "id", idAttributeType);
+
+        // create a wrapper around the id vector
+        openvdb::points::PointAttributeVector<int> idWrapper(id);
+
+        openvdb::points::populateAttribute<openvdb::points::PointDataTree,
+            openvdb::tools::PointIndexTree, openvdb::points::PointAttributeVector<int>>(
+                points->tree(), pointIndexGrid->tree(), "id", idWrapper);
+
+        // use fixed-point codec for radius
+        // note that this attribute type is not registered by default so needs to be
+        // explicitly registered.
+        using Codec = openvdb::points::FixedPointCodec</*1-byte=*/false,
+                openvdb::points::UnitRange>;
+        openvdb::points::TypedAttributeArray<float, Codec>::registerType();
+        auto radiusAttributeType =
+            openvdb::points::TypedAttributeArray<float, Codec>::attributeType();
+        openvdb::points::appendAttribute(points->tree(), "pscale", radiusAttributeType);
+
+        // create a wrapper around the radius vector
+        openvdb::points::PointAttributeVector<float> radiusWrapper(radius);
+
+        openvdb::points::populateAttribute<openvdb::points::PointDataTree,
+            openvdb::tools::PointIndexTree, openvdb::points::PointAttributeVector<float>>(
+                points->tree(), pointIndexGrid->tree(), "pscale", radiusWrapper);
+
+        appendGroup(points->tree(), "odd");
+        appendGroup(points->tree(), "even");
+        appendGroup(points->tree(), "nonzero");
+
+        std::vector<short> oddGroups(positions.size(), 0);
+        oddGroups[1] = 1;
+        oddGroups[3] = 1;
+        std::vector<short> evenGroups(positions.size(), 0);
+        evenGroups[0] = 1;
+        evenGroups[2] = 1;
+        std::vector<short> nonZeroGroups(positions.size(), 1);
+        nonZeroGroups[0] = 0;
+
+        setGroup(points->tree(), pointIndexGrid->tree(), evenGroups, "even");
+        setGroup(points->tree(), pointIndexGrid->tree(), oddGroups, "odd");
+        setGroup(points->tree(), pointIndexGrid->tree(), nonZeroGroups, "nonzero");
+
+        movePoints(*points, deformer);
+
+        // extract data
+
+        std::vector<int> id2;
+        std::vector<float> radius2;
+        std::vector<short> oddGroups2;
+        std::vector<short> evenGroups2;
+        std::vector<short> nonZeroGroups2;
+
+        for (auto leaf = points->tree().cbeginLeaf(); leaf; ++leaf) {
+
+            AttributeHandle<int> idHandle(leaf->constAttributeArray("id"));
+            AttributeHandle<float> pscaleHandle(leaf->constAttributeArray("pscale"));
+            GroupHandle oddHandle(leaf->groupHandle("odd"));
+            GroupHandle evenHandle(leaf->groupHandle("even"));
+            GroupHandle nonZeroHandle(leaf->groupHandle("nonzero"));
+
+            for (auto iter = leaf->beginIndexOn(); iter; ++iter) {
+                id2.push_back(idHandle.get(*iter));
+                radius2.push_back(pscaleHandle.get(*iter));
+                oddGroups2.push_back(oddHandle.get(*iter) ? 1 : 0);
+                evenGroups2.push_back(evenHandle.get(*iter) ? 1 : 0);
+                nonZeroGroups2.push_back(nonZeroHandle.get(*iter) ? 1 : 0);
+            }
+        }
+
+        // new reversed order is (2, 3, 0, 1)
+
+        CPPUNIT_ASSERT_EQUAL(2, id2[0]);
+        CPPUNIT_ASSERT_EQUAL(3, id2[1]);
+        CPPUNIT_ASSERT_EQUAL(0, id2[2]);
+        CPPUNIT_ASSERT_EQUAL(1, id2[3]);
+
+        CPPUNIT_ASSERT(math::isApproxEqual(radius[0], radius2[2], 1e-3f));
+        CPPUNIT_ASSERT(math::isApproxEqual(radius[1], radius2[3], 1e-3f));
+        CPPUNIT_ASSERT(math::isApproxEqual(radius[2], radius2[0], 1e-3f));
+        CPPUNIT_ASSERT(math::isApproxEqual(radius[3], radius2[1], 1e-3f));
+
+        CPPUNIT_ASSERT_EQUAL(short(0), oddGroups2[0]);
+        CPPUNIT_ASSERT_EQUAL(short(1), oddGroups2[1]);
+        CPPUNIT_ASSERT_EQUAL(short(0), oddGroups2[2]);
+        CPPUNIT_ASSERT_EQUAL(short(1), oddGroups2[3]);
+
+        CPPUNIT_ASSERT_EQUAL(short(1), evenGroups2[0]);
+        CPPUNIT_ASSERT_EQUAL(short(0), evenGroups2[1]);
+        CPPUNIT_ASSERT_EQUAL(short(1), evenGroups2[2]);
+        CPPUNIT_ASSERT_EQUAL(short(0), evenGroups2[3]);
+
+        CPPUNIT_ASSERT_EQUAL(short(1), nonZeroGroups2[0]);
+        CPPUNIT_ASSERT_EQUAL(short(1), nonZeroGroups2[1]);
+        CPPUNIT_ASSERT_EQUAL(short(0), nonZeroGroups2[2]);
+        CPPUNIT_ASSERT_EQUAL(short(1), nonZeroGroups2[3]);
+    }
+}
+
+
+// Copyright (c) 2012-2018 DreamWorks Animation LLC
+// All rights reserved. This software is distributed under the
+// Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )


### PR DESCRIPTION
Ability to advect VDB Points through a velocity field and a point move API that relies on defining a custom deformer. In addition, some minor changes to AttributeHandle and the addition of methods to IndexFilters that can indicate whether all or none of the points are evaluated. Support for VDB Points advection has been added to OpenVDB Advect Points SOP. 