### PR TITLE
Improved Point Filtering and Count Optimizations

### DIFF
--- a/openvdb/points/AttributeGroup.h
+++ b/openvdb/points/AttributeGroup.h
@@ -167,6 +167,10 @@ public:
 
     inline bool initialized() const { return bool(mHandle); }
 
+    static index::State state() { return index::PARTIAL; }
+    template <typename LeafT>
+    static index::State state(const LeafT&) { return index::PARTIAL; }
+
     template <typename LeafT>
     void reset(const LeafT& leaf) {
         mHandle.reset(new GroupHandle(leaf.groupHandle(mIndex)));

--- a/openvdb/points/IndexFilter.h
+++ b/openvdb/points/IndexFilter.h
@@ -126,6 +126,7 @@ generateRandomSubset(const unsigned int seed, const IntType n, const IntType m)
 } // namespace index_filter_internal
 
 
+/// Index filtering on active / inactive state of host voxel
 template <bool On>
 class ValueMaskFilter
 {
@@ -146,7 +147,7 @@ public:
     template <typename IterT>
     bool valid(const IterT& iter) const
     {
-        const bool valueOn = iter.valueIter().isValueOn();
+        const bool valueOn = iter.isValueOn();
         return On ? valueOn : !valueOn;
     }
 };

--- a/openvdb/points/IndexFilter.h
+++ b/openvdb/points/IndexFilter.h
@@ -33,6 +33,33 @@
 /// @author Dan Bailey
 ///
 /// @brief  Index filters primarily designed to be used with a FilterIndexIter.
+///
+/// Filters must adhere to the interface described in the example below:
+/// @code
+/// struct MyFilter
+/// {
+///     // Return true when the filter has been initialized for first use
+///     bool initialized() { return true; }
+///
+///     // Return index::ALL if all points are valid, index::NONE if no points are valid
+///     // and index::PARTIAL if some points are valid
+///     index::State state() { return index::PARTIAL; }
+///
+///     // Return index::ALL if all points in this leaf are valid, index::NONE if no points
+///     // in this leaf are valid and index::PARTIAL if some points in this leaf are valid
+///     template <typename LeafT>
+///     index::State state(const LeafT&) { return index::PARTIAL; }
+///
+///     // Resets the filter to refer to the specified leaf, all subsequent valid() calls
+///     // will be relative to this leaf until reset() is called with a different leaf.
+///     // Although a required method, many filters will provide an empty implementation if
+///     // there is no leaf-specific logic needed.
+///     template <typename LeafT> void reset(const LeafT&) { }
+///
+///     // Returns true if the filter is valid for the supplied iterator
+///     template <typename IterT> bool valid(const IterT&) { return true; }
+/// };
+/// @endcode
 
 #ifndef OPENVDB_POINTS_INDEX_FILTER_HAS_BEEN_INCLUDED
 #define OPENVDB_POINTS_INDEX_FILTER_HAS_BEEN_INCLUDED
@@ -63,6 +90,7 @@ namespace points {
 
 
 ////////////////////////////////////////
+
 
 
 namespace index_filter_internal {
@@ -96,6 +124,36 @@ generateRandomSubset(const unsigned int seed, const IntType n, const IntType m)
 
 
 } // namespace index_filter_internal
+
+
+template <bool On>
+class ValueMaskFilter
+{
+public:
+    static bool initialized() { return true; }
+    static index::State state() { return index::PARTIAL; }
+    template <typename LeafT>
+    static index::State state(const LeafT& leaf)
+    {
+        if (leaf.isDense())         return On ? index::ALL : index::NONE;
+        else if (leaf.isEmpty())    return On ? index::NONE : index::ALL;
+        return index::PARTIAL;
+    }
+
+    template <typename LeafT>
+    void reset(const LeafT& leaf) { }
+
+    template <typename IterT>
+    bool valid(const IterT& iter) const
+    {
+        const bool valueOn = iter.valueIter().isValueOn();
+        return On ? valueOn : !valueOn;
+    }
+};
+
+
+using ActiveFilter = ValueMaskFilter<true>;
+using InActiveFilter = ValueMaskFilter<false>;
 
 
 /// Index filtering on multiple group membership for inclusion and exclusion
@@ -142,15 +200,23 @@ public:
 
     inline bool initialized() const { return mInitialized; }
 
+    inline index::State state() const
+    {
+        return (mInclude.empty() && mExclude.empty()) ? index::ALL : index::PARTIAL;
+    }
+
+    template <typename LeafT>
+    static index::State state(const LeafT&) { return index::PARTIAL; }
+
     template <typename LeafT>
     void reset(const LeafT& leaf) {
         mIncludeHandles.clear();
         mExcludeHandles.clear();
-        for (const AttributeSet::Descriptor::GroupIndex& index : mInclude) {
-            mIncludeHandles.emplace_back(leaf.groupHandle(index));
+        for (const auto& i : mInclude) {
+            mIncludeHandles.emplace_back(leaf.groupHandle(i));
         }
-        for (const AttributeSet::Descriptor::GroupIndex& index : mExclude) {
-            mExcludeHandles.emplace_back(leaf.groupHandle(index));
+        for (const auto& i : mExclude) {
+            mExcludeHandles.emplace_back(leaf.groupHandle(i));
         }
         mInitialized = true;
     }
@@ -226,6 +292,10 @@ public:
 
     inline bool initialized() const { return mNextIndex == -1; }
 
+    static index::State state() { return index::PARTIAL; }
+    template <typename LeafT>
+    static index::State state(const LeafT&) { return index::PARTIAL; }
+
     template <typename LeafT>
     void reset(const LeafT& leaf) {
         using index_filter_internal::generateRandomSubset;
@@ -297,6 +367,10 @@ public:
 
     inline bool initialized() const { return bool(mIdHandle); }
 
+    static index::State state() { return index::PARTIAL; }
+    template <typename LeafT>
+    static index::State state(const LeafT&) { return index::PARTIAL; }
+
     template <typename LeafT>
     void reset(const LeafT& leaf) {
         assert(leaf.hasAttribute(mIndex));
@@ -349,6 +423,10 @@ public:
     }
 
     inline bool initialized() const { return bool(mPositionHandle); }
+
+    static index::State state() { return index::PARTIAL; }
+    template <typename LeafT>
+    static index::State state(const LeafT&) { return index::PARTIAL; }
 
     template <typename LeafT>
     void reset(const LeafT& leaf) {
@@ -410,6 +488,13 @@ public:
 
     inline bool initialized() const { return bool(mPositionHandle); }
 
+    inline index::State state() const
+    {
+        return mBbox.empty() ? index::NONE : index::PARTIAL;
+    }
+    template <typename LeafT>
+    static index::State state(const LeafT&) { return index::PARTIAL; }
+
     template <typename LeafT>
     void reset(const LeafT& leaf) {
         mPositionHandle.reset(new Handle(leaf.constAttributeArray("P")));
@@ -450,6 +535,16 @@ public:
 
     inline bool initialized() const { return mFilter1.initialized() && mFilter2.initialized(); }
 
+    inline index::State state() const
+    {
+        return this->computeState(mFilter1.state(), mFilter2.state());
+    }
+    template <typename LeafT>
+    inline index::State state(const LeafT& leaf) const
+    {
+        return this->computeState(mFilter1.state(leaf), mFilter2.state(leaf));
+    }
+
     template <typename LeafT>
     void reset(const LeafT& leaf) {
         mFilter1.reset(leaf);
@@ -463,6 +558,19 @@ public:
     }
 
 private:
+    inline index::State computeState(   index::State state1,
+                                        index::State state2) const
+    {
+        if (And) {
+            if (state1 == index::NONE || state2 == index::NONE)       return index::NONE;
+            else if (state1 == index::ALL && state2 == index::ALL)    return index::ALL;
+        } else {
+            if (state1 == index::NONE && state2 == index::NONE)       return index::NONE;
+            else if (state1 == index::ALL && state2 == index::ALL)    return index::ALL;
+        }
+        return index::PARTIAL;
+    }
+
     T1 mFilter1;
     T2 mFilter2;
 }; // class BinaryFilter

--- a/openvdb/points/IndexFilter.h
+++ b/openvdb/points/IndexFilter.h
@@ -154,7 +154,7 @@ public:
 
 
 using ActiveFilter = ValueMaskFilter<true>;
-using InActiveFilter = ValueMaskFilter<false>;
+using InactiveFilter = ValueMaskFilter<false>;
 
 
 /// Index filtering on multiple group membership for inclusion and exclusion

--- a/openvdb/points/IndexIterator.h
+++ b/openvdb/points/IndexIterator.h
@@ -58,11 +58,30 @@ inline Index64 iterCount(const IterT& iter);
 ////////////////////////////////////////
 
 
+namespace index {
+// Enum for informing early-exit optimizations
+// PARTIAL - No optimizations are possible
+// NONE - No indices to evaluate, can skip computation
+// ALL - All indices to evaluate, can skip filtering
+enum State
+{
+    PARTIAL=0,
+    NONE,
+    ALL
+};
+}
+
+
 /// @brief A no-op filter that can be used when iterating over all indices
+/// @see points/IndexFilter.h for the documented interface for an index filter
 class NullFilter
 {
 public:
     static bool initialized() { return true; }
+    static index::State state() { return index::ALL; }
+    template <typename LeafT>
+    static index::State state(const LeafT&) { return index::ALL; }
+
     template <typename LeafT> void reset(const LeafT&) { }
     template <typename IterT> static bool valid(const IterT&) { return true; }
 }; // class NullFilter

--- a/openvdb/points/IndexIterator.h
+++ b/openvdb/points/IndexIterator.h
@@ -125,13 +125,16 @@ public:
     Index32 offset() { return mOffset; }
     inline bool next() { this->operator++(); return this->test(); }
 
-    /// @brief For efficiency, Coord assumed to be readily available
+    /// @brief For efficiency, Coord and active state assumed to be readily available
     /// when iterating over indices of a single voxel
     Coord getCoord [[noreturn]] () const {
         OPENVDB_THROW(RuntimeError, "ValueVoxelCIter does not provide a valid Coord.");
     }
     void getCoord [[noreturn]] (Coord& /*coord*/) const {
         OPENVDB_THROW(RuntimeError, "ValueVoxelCIter does not provide a valid Coord.");
+    }
+    bool isValueOn [[noreturn]] () const {
+        OPENVDB_THROW(RuntimeError, "ValueVoxelCIter does not test if voxel is active.");
     }
 
     /// @{
@@ -218,6 +221,9 @@ public:
         inline Coord getCoord() const { assert(mIter); return mIter.getCoord(); }
         /// Return in @a xyz the coordinates of the item to which the value iterator is pointing.
         inline void getCoord(Coord& xyz) const { assert(mIter); xyz = mIter.getCoord(); }
+
+        /// @brief Return @c true if this iterator is pointing to an active value.
+        inline bool isValueOn() const { assert(mIter); return mIter.isValueOn(); }
 
         /// Return the const value iterator
         inline const IteratorT& valueIter() const { return mIter; }
@@ -314,6 +320,9 @@ public:
     inline Coord getCoord() const { assert(mIterator); return mIterator.getCoord(); }
     /// Return in @a xyz the coordinates of the item to which the value iterator is pointing.
     inline void getCoord(Coord& xyz) const { assert(mIterator); xyz = mIterator.getCoord(); }
+
+    /// @brief Return @c true if the value iterator is pointing to an active value.
+    inline bool isValueOn() const { assert(mIterator); return mIterator.valueIter().isValueOn(); }
 
     /// @brief Equality operators
     bool operator==(const IndexIter& other) const { return mIterator == other.mIterator; }

--- a/openvdb/points/PointConversion.h
+++ b/openvdb/points/PointConversion.h
@@ -83,9 +83,10 @@ template<
     typename PositionArrayT,
     typename PointIndexGridT>
 inline typename PointDataGridT::Ptr
-createPointDataGrid(
-    const PointIndexGridT& pointIndexGrid, const PositionArrayT& positions,
-    const math::Transform& xform, Metadata::Ptr positionDefaultValue = Metadata::Ptr());
+createPointDataGrid(const PointIndexGridT& pointIndexGrid,
+                    const PositionArrayT& positions,
+                    const math::Transform& xform,
+                    Metadata::Ptr positionDefaultValue = Metadata::Ptr());
 
 
 /// @brief  Convenience method to create a @c PointDataGrid from a std::vector of
@@ -100,7 +101,8 @@ createPointDataGrid(
 
 template <typename CompressionT, typename PointDataGridT, typename ValueT>
 inline typename PointDataGridT::Ptr
-createPointDataGrid(const std::vector<ValueT>& positions, const math::Transform& xform,
+createPointDataGrid(const std::vector<ValueT>& positions,
+                    const math::Transform& xform,
                     Metadata::Ptr positionDefaultValue = Metadata::Ptr());
 
 
@@ -117,9 +119,12 @@ createPointDataGrid(const std::vector<ValueT>& positions, const math::Transform&
 ///         operation. This is required to ensure the same point index ordering.
 template <typename PointDataTreeT, typename PointIndexTreeT, typename PointArrayT>
 inline void
-populateAttribute(  PointDataTreeT& tree, const PointIndexTreeT& pointIndexTree,
-                    const openvdb::Name& attributeName, const PointArrayT& data,
-                    const Index stride = 1, const bool insertMetadata = true);
+populateAttribute(  PointDataTreeT& tree,
+                    const PointIndexTreeT& pointIndexTree,
+                    const openvdb::Name& attributeName,
+                    const PointArrayT& data,
+                    const Index stride = 1,
+                    const bool insertMetadata = true);
 
 /// @brief Convert the position attribute from a Point Data Grid
 ///
@@ -127,19 +132,17 @@ populateAttribute(  PointDataTreeT& tree, const PointIndexTreeT& pointIndexTree,
 /// @param grid                 the PointDataGrid to be converted.
 /// @param pointOffsets         a vector of cumulative point offsets for each leaf
 /// @param startOffset          a value to shift all the point offsets by
-/// @param includeGroups        a vector of VDB Points groups to be included (default is all)
-/// @param excludeGroups        a vector of VDB Points groups to be excluded (default is none)
+/// @param filter               an index filter
 /// @param inCoreOnly           true if out-of-core leaf nodes are to be ignored
 ///
 
-template <typename PositionAttribute, typename PointDataGridT>
+template <typename PositionAttribute, typename PointDataGridT, typename FilterT = NullFilter>
 inline void
 convertPointDataGridPosition(   PositionAttribute& positionAttribute,
                                 const PointDataGridT& grid,
                                 const std::vector<Index64>& pointOffsets,
                                 const Index64 startOffset,
-                                const std::vector<Name>& includeGroups = std::vector<Name>(),
-                                const std::vector<Name>& excludeGroups = std::vector<Name>(),
+                                const FilterT& filter = NullFilter(),
                                 const bool inCoreOnly = false);
 
 
@@ -151,10 +154,9 @@ convertPointDataGridPosition(   PositionAttribute& positionAttribute,
 /// @param startOffset          a value to shift all the point offsets by
 /// @param arrayIndex           the index in the Descriptor of the array to be converted.
 /// @param stride               the stride of the attribute
-/// @param includeGroups        a vector of VDB Points groups to be included (default is all)
-/// @param excludeGroups        a vector of VDB Points groups to be excluded (default is none)
+/// @param filter               an index filter
 /// @param inCoreOnly           true if out-of-core leaf nodes are to be ignored
-template <typename TypedAttribute, typename PointDataTreeT>
+template <typename TypedAttribute, typename PointDataTreeT, typename FilterT = NullFilter>
 inline void
 convertPointDataGridAttribute(  TypedAttribute& attribute,
                                 const PointDataTreeT& tree,
@@ -162,8 +164,7 @@ convertPointDataGridAttribute(  TypedAttribute& attribute,
                                 const Index64 startOffset,
                                 const unsigned arrayIndex,
                                 const Index stride = 1,
-                                const std::vector<Name>& includeGroups = std::vector<Name>(),
-                                const std::vector<Name>& excludeGroups = std::vector<Name>(),
+                                const FilterT& filter = NullFilter(),
                                 const bool inCoreOnly = false);
 
 
@@ -179,15 +180,14 @@ convertPointDataGridAttribute(  TypedAttribute& attribute,
 /// @param inCoreOnly           true if out-of-core leaf nodes are to be ignored
 ///
 
-template <typename Group, typename PointDataTreeT>
+template <typename Group, typename PointDataTreeT, typename FilterT = NullFilter>
 inline void
 convertPointDataGridGroup(  Group& group,
                             const PointDataTreeT& tree,
                             const std::vector<Index64>& pointOffsets,
                             const Index64 startOffset,
                             const AttributeSet::Descriptor::GroupIndex index,
-                            const std::vector<Name>& includeGroups = std::vector<Name>(),
-                            const std::vector<Name>& excludeGroups = std::vector<Name>(),
+                            const FilterT& filter = NullFilter(),
                             const bool inCoreOnly = false);
 
 /// @ brief Given a container of world space positions and a target points per voxel,
@@ -443,11 +443,13 @@ struct PopulateAttributeOp {
     const Index                 mStride;
 };
 
-template<typename PointDataTreeType, typename Attribute>
+template<typename PointDataTreeType, typename Attribute, typename FilterT>
 struct ConvertPointDataGridPositionOp {
 
     using LeafNode      = typename PointDataTreeType::LeafNodeType;
     using ValueType     = typename Attribute::ValueType;
+    using HandleT       = typename Attribute::Handle;
+    using SourceHandleT = AttributeHandle<ValueType>;
     using LeafManagerT  = typename tree::LeafManager<const PointDataTreeType>;
     using LeafRangeT    = typename LeafManagerT::LeafRange;
 
@@ -456,16 +458,14 @@ struct ConvertPointDataGridPositionOp {
                                     const Index64 startOffset,
                                     const math::Transform& transform,
                                     const size_t index,
-                                    const std::vector<Name>& includeGroups = std::vector<Name>(),
-                                    const std::vector<Name>& excludeGroups = std::vector<Name>(),
-                                    const bool inCoreOnly = false)
+                                    const FilterT& filter,
+                                    const bool inCoreOnly)
         : mAttribute(attribute)
         , mPointOffsets(pointOffsets)
         , mStartOffset(startOffset)
         , mTransform(transform)
         , mIndex(index)
-        , mIncludeGroups(includeGroups)
-        , mExcludeGroups(excludeGroups)
+        , mFilter(filter)
         , mInCoreOnly(inCoreOnly)
     {
         // only accept Vec3f as ValueType
@@ -474,11 +474,22 @@ struct ConvertPointDataGridPositionOp {
                       "ValueType is not Vec3f");
     }
 
-    void operator()(const LeafRangeT& range) const {
+    template <typename IterT>
+    void convert(IterT& iter, HandleT& targetHandle,
+        SourceHandleT& sourceHandle, Index64& offset) const
+    {
+        for (; iter; ++iter) {
+            const Vec3d xyz = iter.getCoord().asVec3d();
+            const Vec3d pos = sourceHandle.get(*iter);
+            targetHandle.set(static_cast<Index>(offset++), /*stride=*/0,
+                mTransform.indexToWorld(pos + xyz));
+        }
+    }
 
-        const bool useGroups = !mIncludeGroups.empty() || !mExcludeGroups.empty();
-
-        typename Attribute::Handle pHandle(mAttribute);
+    void operator()(const LeafRangeT& range) const
+    {
+        FilterT newFilter(mFilter);
+        HandleT pHandle(mAttribute);
 
         for (auto leaf = range.begin(); leaf; ++leaf) {
 
@@ -490,27 +501,15 @@ struct ConvertPointDataGridPositionOp {
 
             if (leaf.pos() > 0) offset += mPointOffsets[leaf.pos() - 1];
 
-            auto handle = AttributeHandle<ValueType>::create(leaf->constAttributeArray(mIndex));
+            auto handle = SourceHandleT::create(leaf->constAttributeArray(mIndex));
 
-            if (useGroups) {
-                auto iter = leaf->beginIndexOn(MultiGroupFilter(mIncludeGroups, mExcludeGroups, leaf->attributeSet()));
-
-                for (; iter; ++iter) {
-                    const Vec3d xyz = iter.getCoord().asVec3d();
-                    const Vec3d pos = handle->get(*iter);
-                    pHandle.set(static_cast<Index>(offset++), /*stride=*/0,
-                        mTransform.indexToWorld(pos + xyz));
-                }
+            if (mFilter.state() == index::ALL) {
+                auto iter = leaf->beginIndexOn();
+                convert(iter, pHandle, *handle, offset);
             }
             else {
-                auto iter = leaf->beginIndexOn();
-
-                for (; iter; ++iter) {
-                    const Vec3d xyz = iter.getCoord().asVec3d();
-                    const Vec3d pos = handle->get(*iter);
-                    pHandle.set(static_cast<Index>(offset++), /*stride=*/0,
-                        mTransform.indexToWorld(pos + xyz));
-                }
+                auto iter = leaf->beginIndexOn(newFilter);
+                convert(iter, pHandle, *handle, offset);
             }
         }
     }
@@ -522,18 +521,18 @@ struct ConvertPointDataGridPositionOp {
     const Index64                           mStartOffset;
     const math::Transform&                  mTransform;
     const size_t                            mIndex;
-    const std::vector<std::string>&         mIncludeGroups;
-    const std::vector<std::string>&         mExcludeGroups;
+    const FilterT&                          mFilter;
     const bool                              mInCoreOnly;
 }; // ConvertPointDataGridPositionOp
 
 
-template<typename PointDataTreeType, typename Attribute>
+template<typename PointDataTreeType, typename Attribute, typename FilterT>
 struct ConvertPointDataGridAttributeOp {
 
     using LeafNode      = typename PointDataTreeType::LeafNodeType;
     using ValueType     = typename Attribute::ValueType;
-    using HandleT       = typename ConversionTraits<ValueType>::Handle;
+    using HandleT       = typename Attribute::Handle;
+    using SourceHandleT = typename ConversionTraits<ValueType>::Handle;
     using LeafManagerT  = typename tree::LeafManager<const PointDataTreeType>;
     using LeafRangeT    = typename LeafManagerT::LeafRange;
 
@@ -541,24 +540,45 @@ struct ConvertPointDataGridAttributeOp {
                                     const std::vector<Index64>& pointOffsets,
                                     const Index64 startOffset,
                                     const size_t index,
-                                    const Index stride = 1,
-                                    const std::vector<Name>& includeGroups = std::vector<Name>(),
-                                    const std::vector<Name>& excludeGroups = std::vector<Name>(),
-                                    const bool inCoreOnly = false)
+                                    const Index stride,
+                                    const FilterT& filter,
+                                    const bool inCoreOnly)
         : mAttribute(attribute)
         , mPointOffsets(pointOffsets)
         , mStartOffset(startOffset)
         , mIndex(index)
         , mStride(stride)
-        , mIncludeGroups(includeGroups)
-        , mExcludeGroups(excludeGroups)
+        , mFilter(filter)
         , mInCoreOnly(inCoreOnly) { }
 
-    void operator()(const LeafRangeT& range) const {
+    template <typename IterT>
+    void convert(IterT& iter, HandleT& targetHandle,
+        SourceHandleT& sourceHandle, Index64& offset) const
+    {
+        if (sourceHandle.isUniform()) {
+            const ValueType uniformValue(sourceHandle.get(0));
+            for (; iter; ++iter) {
+                for (Index i = 0; i < mStride; i++) {
+                    targetHandle.set(static_cast<Index>(offset), i, uniformValue);
+                }
+                offset++;
+            }
+        }
+        else {
+            for (; iter; ++iter) {
+                for (Index i = 0; i < mStride; i++) {
+                    targetHandle.set(static_cast<Index>(offset), i,
+                        sourceHandle.get(*iter, /*stride=*/i));
+                }
+                offset++;
+            }
+        }
+    }
 
-        const bool useGroups = !mIncludeGroups.empty() || !mExcludeGroups.empty();
-
-        typename Attribute::Handle pHandle(mAttribute);
+    void operator()(const LeafRangeT& range) const
+    {
+        FilterT newFilter(mFilter);
+        HandleT pHandle(mAttribute);
 
         for (auto leaf = range.begin(); leaf; ++leaf) {
 
@@ -570,54 +590,15 @@ struct ConvertPointDataGridAttributeOp {
 
             if (leaf.pos() > 0) offset += mPointOffsets[leaf.pos() - 1];
 
-            typename HandleT::Ptr handle = ConversionTraits<ValueType>::handleFromLeaf(
+            typename SourceHandleT::Ptr handle = ConversionTraits<ValueType>::handleFromLeaf(
                 *leaf, static_cast<Index>(mIndex));
 
-            const bool uniform = handle->isUniform();
-
-            ValueType uniformValue = ConversionTraits<ValueType>::zero();
-            if (uniform)    uniformValue = ValueType(handle->get(0));
-
-            if (useGroups) {
-                auto iter = leaf->beginIndexOn(MultiGroupFilter(mIncludeGroups, mExcludeGroups, leaf->attributeSet()));
-
-                if (uniform) {
-                    for (; iter; ++iter) {
-                        for (Index i = 0; i < mStride; i++) {
-                            pHandle.set(static_cast<Index>(offset), i, uniformValue);
-                        }
-                        offset++;
-                    }
-                }
-                else {
-                    for (; iter; ++iter) {
-                        for (Index i = 0; i < mStride; i++) {
-                            pHandle.set(static_cast<Index>(offset), i, handle->get(*iter));
-                        }
-                        offset++;
-                    }
-                }
-            }
-            else {
+            if (mFilter.state() == index::ALL) {
                 auto iter = leaf->beginIndexOn();
-
-                if (uniform) {
-                    for (; iter; ++iter) {
-                        for (Index i = 0; i < mStride; i++) {
-                            pHandle.set(static_cast<Index>(offset), i, uniformValue);
-                        }
-                        offset++;
-                    }
-                }
-                else {
-                    for (; iter; ++iter) {
-                        for (Index i = 0; i < mStride; i++) {
-                            pHandle.set(static_cast<Index>(offset), i,
-                                handle->get(*iter, /*stride=*/i));
-                        }
-                        offset++;
-                    }
-                }
+                convert(iter, pHandle, *handle, offset);
+            } else {
+                auto iter = leaf->beginIndexOn(newFilter);
+                convert(iter, pHandle, *handle, offset);
             }
         }
     }
@@ -629,12 +610,11 @@ struct ConvertPointDataGridAttributeOp {
     const Index64                           mStartOffset;
     const size_t                            mIndex;
     const Index                             mStride;
-    const std::vector<std::string>&         mIncludeGroups;
-    const std::vector<std::string>&         mExcludeGroups;
+    const FilterT&                          mFilter;
     const bool                              mInCoreOnly;
 }; // ConvertPointDataGridAttributeOp
 
-template<typename PointDataTreeType, typename Group>
+template<typename PointDataTreeType, typename Group, typename FilterT>
 struct ConvertPointDataGridGroupOp {
 
     using LeafNode      = typename PointDataTreeType::LeafNodeType;
@@ -646,20 +626,41 @@ struct ConvertPointDataGridGroupOp {
                                 const std::vector<Index64>& pointOffsets,
                                 const Index64 startOffset,
                                 const AttributeSet::Descriptor::GroupIndex index,
-                                const std::vector<Name>& includeGroups = std::vector<Name>(),
-                                const std::vector<Name>& excludeGroups = std::vector<Name>(),
-                                const bool inCoreOnly = false)
+                                const FilterT& filter,
+                                const bool inCoreOnly)
         : mGroup(group)
         , mPointOffsets(pointOffsets)
         , mStartOffset(startOffset)
         , mIndex(index)
-        , mIncludeGroups(includeGroups)
-        , mExcludeGroups(excludeGroups)
+        , mFilter(filter)
         , mInCoreOnly(inCoreOnly) { }
 
-    void operator()(const LeafRangeT& range) const {
+    template <typename IterT>
+    void convert(IterT& iter, const GroupAttributeArray& groupArray, Index64& offset) const
+    {
+        const auto bitmask = static_cast<GroupType>(1 << mIndex.second);
 
-        const bool useGroups = !mIncludeGroups.empty() || !mExcludeGroups.empty();
+        if (groupArray.isUniform()) {
+            if (groupArray.get(0) & bitmask) {
+                for (; iter; ++iter) {
+                    mGroup.setOffsetOn(static_cast<Index>(offset));
+                    offset++;
+                }
+            }
+        }
+        else {
+            for (; iter; ++iter) {
+                if (groupArray.get(*iter) & bitmask) {
+                    mGroup.setOffsetOn(static_cast<Index>(offset));
+                }
+                offset++;
+            }
+        }
+    }
+
+    void operator()(const LeafRangeT& range) const
+    {
+        FilterT newFilter(mFilter);
 
         for (auto leaf = range.begin(); leaf; ++leaf) {
 
@@ -672,53 +673,16 @@ struct ConvertPointDataGridGroupOp {
             if (leaf.pos() > 0)     offset += mPointOffsets[leaf.pos() - 1];
 
             const AttributeArray& array = leaf->constAttributeArray(mIndex.first);
-            const auto bitmask = static_cast<GroupType>(1 << mIndex.second);
-
             assert(isGroup(array));
-
             const GroupAttributeArray& groupArray = GroupAttributeArray::cast(array);
 
-            const bool uniform = groupArray.isUniform();
-
-            if (uniform) {
-                if (!(groupArray.get(0) & bitmask))     continue;
-            }
-
-            if (useGroups) {
-                auto iter = leaf->beginIndexOn(MultiGroupFilter(mIncludeGroups, mExcludeGroups, leaf->attributeSet()));
-
-                if (uniform) {
-                    for (; iter; ++iter) {
-                        mGroup.setOffsetOn(static_cast<Index>(offset));
-                        offset++;
-                    }
-                }
-                else {
-                    for (; iter; ++iter) {
-                        if (groupArray.get(*iter) & bitmask) {
-                            mGroup.setOffsetOn(static_cast<Index>(offset));
-                        }
-                        offset++;
-                    }
-                }
+            if (mFilter.state() == index::ALL) {
+                auto iter = leaf->beginIndexOn();
+                convert(iter, groupArray, offset);
             }
             else {
-                auto iter = leaf->beginIndexOn();
-
-                if (uniform) {
-                    for (; iter; ++iter) {
-                        mGroup.setOffsetOn(static_cast<Index>(offset));
-                        offset++;
-                    }
-                }
-                else {
-                    for (; iter; ++iter) {
-                        if (groupArray.get(*iter) & bitmask) {
-                            mGroup.setOffsetOn(static_cast<Index>(offset));
-                        }
-                        offset++;
-                    }
-                }
+                auto iter = leaf->beginIndexOn(newFilter);
+                convert(iter, groupArray, offset);
             }
         }
     }
@@ -729,8 +693,7 @@ struct ConvertPointDataGridGroupOp {
     const std::vector<Index64>&             mPointOffsets;
     const Index64                           mStartOffset;
     const GroupIndex                        mIndex;
-    const std::vector<std::string>&         mIncludeGroups;
-    const std::vector<std::string>&         mExcludeGroups;
+    const FilterT&                          mFilter;
     const bool                              mInCoreOnly;
 }; // ConvertPointDataGridGroupOp
 
@@ -891,14 +854,13 @@ populateAttribute(PointDataTreeT& tree, const PointIndexTreeT& pointIndexTree,
 ////////////////////////////////////////
 
 
-template <typename PositionAttribute, typename PointDataGridT>
+template <typename PositionAttribute, typename PointDataGridT, typename FilterT>
 inline void
 convertPointDataGridPosition(   PositionAttribute& positionAttribute,
                                 const PointDataGridT& grid,
                                 const std::vector<Index64>& pointOffsets,
                                 const Index64 startOffset,
-                                const std::vector<Name>& includeGroups,
-                                const std::vector<Name>& excludeGroups,
+                                const FilterT& filter,
                                 const bool inCoreOnly)
 {
     using TreeType      = typename PointDataGridT::TreeType;
@@ -911,24 +873,13 @@ convertPointDataGridPosition(   PositionAttribute& positionAttribute,
 
     if (!iter)  return;
 
-    // for efficiency, keep only groups that are present in the Descriptor
-
-    const AttributeSet::Descriptor& descriptor = iter->attributeSet().descriptor();
-
-    std::vector<Name> newIncludeGroups(includeGroups);
-    std::vector<Name> newExcludeGroups(excludeGroups);
-
-    deleteMissingPointGroups(newIncludeGroups, descriptor);
-    deleteMissingPointGroups(newExcludeGroups, descriptor);
-
-    LeafManagerT leafManager(tree);
-
     const size_t positionIndex = iter->attributeSet().find("P");
 
     positionAttribute.expand();
-    ConvertPointDataGridPositionOp<TreeType, PositionAttribute> convert(
+    LeafManagerT leafManager(tree);
+    ConvertPointDataGridPositionOp<TreeType, PositionAttribute, FilterT> convert(
                     positionAttribute, pointOffsets, startOffset, grid.transform(), positionIndex,
-                    newIncludeGroups, newExcludeGroups, inCoreOnly);
+                    filter, inCoreOnly);
     tbb::parallel_for(leafManager.leafRange(), convert);
     positionAttribute.compact();
 }
@@ -937,7 +888,7 @@ convertPointDataGridPosition(   PositionAttribute& positionAttribute,
 ////////////////////////////////////////
 
 
-template <typename TypedAttribute, typename PointDataTreeT>
+template <typename TypedAttribute, typename PointDataTreeT, typename FilterT>
 inline void
 convertPointDataGridAttribute(  TypedAttribute& attribute,
                                 const PointDataTreeT& tree,
@@ -945,8 +896,7 @@ convertPointDataGridAttribute(  TypedAttribute& attribute,
                                 const Index64 startOffset,
                                 const unsigned arrayIndex,
                                 const Index stride,
-                                const std::vector<Name>& includeGroups,
-                                const std::vector<Name>& excludeGroups,
+                                const FilterT& filter,
                                 const bool inCoreOnly)
 {
     using LeafManagerT = typename tree::LeafManager<const PointDataTreeT>;
@@ -957,22 +907,11 @@ convertPointDataGridAttribute(  TypedAttribute& attribute,
 
     if (!iter)  return;
 
-    // for efficiency, keep only groups that are present in the Descriptor
-
-    const AttributeSet::Descriptor& descriptor = iter->attributeSet().descriptor();
-
-    std::vector<Name> newIncludeGroups(includeGroups);
-    std::vector<Name> newExcludeGroups(excludeGroups);
-
-    deleteMissingPointGroups(newIncludeGroups, descriptor);
-    deleteMissingPointGroups(newExcludeGroups, descriptor);
-
-    LeafManagerT leafManager(tree);
-
     attribute.expand();
-    ConvertPointDataGridAttributeOp<PointDataTreeT, TypedAttribute> convert(
+    LeafManagerT leafManager(tree);
+    ConvertPointDataGridAttributeOp<PointDataTreeT, TypedAttribute, FilterT> convert(
                         attribute, pointOffsets, startOffset, arrayIndex, stride,
-                        newIncludeGroups, newExcludeGroups, inCoreOnly);
+                        filter, inCoreOnly);
         tbb::parallel_for(leafManager.leafRange(), convert);
     attribute.compact();
 }
@@ -981,15 +920,14 @@ convertPointDataGridAttribute(  TypedAttribute& attribute,
 ////////////////////////////////////////
 
 
-template <typename Group, typename PointDataTreeT>
+template <typename Group, typename PointDataTreeT, typename FilterT>
 inline void
 convertPointDataGridGroup(  Group& group,
                             const PointDataTreeT& tree,
                             const std::vector<Index64>& pointOffsets,
                             const Index64 startOffset,
                             const AttributeSet::Descriptor::GroupIndex index,
-                            const std::vector<Name>& includeGroups,
-                            const std::vector<Name>& excludeGroups,
+                            const FilterT& filter,
                             const bool inCoreOnly)
 {
     using LeafManagerT= typename tree::LeafManager<const PointDataTreeT>;
@@ -997,24 +935,12 @@ convertPointDataGridGroup(  Group& group,
     using point_conversion_internal::ConvertPointDataGridGroupOp;
 
     auto iter = tree.cbeginLeaf();
-
     if (!iter)  return;
 
-    // for efficiency, keep only groups that are present in the Descriptor
-
-    const AttributeSet::Descriptor& descriptor = iter->attributeSet().descriptor();
-
-    std::vector<Name> newIncludeGroups(includeGroups);
-    std::vector<Name> newExcludeGroups(excludeGroups);
-
-    deleteMissingPointGroups(newIncludeGroups, descriptor);
-    deleteMissingPointGroups(newExcludeGroups, descriptor);
-
     LeafManagerT leafManager(tree);
-
-    ConvertPointDataGridGroupOp<PointDataTree, Group> convert(
+    ConvertPointDataGridGroupOp<PointDataTree, Group, FilterT> convert(
                     group, pointOffsets, startOffset, index,
-                    newIncludeGroups, newExcludeGroups, inCoreOnly);
+                    filter, inCoreOnly);
     tbb::parallel_for(leafManager.leafRange(), convert);
 
     // must call this after modifying point groups in parallel
@@ -1188,6 +1114,72 @@ computeVoxelSize(  const PositionWrapper& positions,
     // truncate the voxel size for readability and return the value
 
     return Local::truncate(voxelSize, decimalPlaces);
+}
+
+
+////////////////////////////////////////
+
+
+// deprecated functions
+
+
+template <typename PositionAttribute, typename PointDataGridT>
+OPENVDB_DEPRECATED
+inline void
+convertPointDataGridPosition(   PositionAttribute& positionAttribute,
+                                const PointDataGridT& grid,
+                                const std::vector<Index64>& pointOffsets,
+                                const Index64 startOffset,
+                                const std::vector<Name>& includeGroups,
+                                const std::vector<Name>& excludeGroups,
+                                const bool inCoreOnly = false)
+{
+    auto leaf = grid.tree().cbeginLeaf();
+    if (!leaf)  return;
+    MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+    convertPointDataGridPosition(positionAttribute, grid, pointOffsets, startOffset,
+        filter, inCoreOnly);
+}
+
+
+template <typename TypedAttribute, typename PointDataTreeT>
+OPENVDB_DEPRECATED
+inline void
+convertPointDataGridAttribute(  TypedAttribute& attribute,
+                                const PointDataTreeT& tree,
+                                const std::vector<Index64>& pointOffsets,
+                                const Index64 startOffset,
+                                const unsigned arrayIndex,
+                                const Index stride,
+                                const std::vector<Name>& includeGroups,
+                                const std::vector<Name>& excludeGroups,
+                                const bool inCoreOnly = false)
+{
+    auto leaf = tree.cbeginLeaf();
+    if (!leaf)  return;
+    MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+    convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset,
+        arrayIndex, stride, filter, inCoreOnly);
+}
+
+
+template <typename Group, typename PointDataTreeT>
+OPENVDB_DEPRECATED
+inline void
+convertPointDataGridGroup(  Group& group,
+                            const PointDataTreeT& tree,
+                            const std::vector<Index64>& pointOffsets,
+                            const Index64 startOffset,
+                            const AttributeSet::Descriptor::GroupIndex index,
+                            const std::vector<Name>& includeGroups,
+                            const std::vector<Name>& excludeGroups,
+                            const bool inCoreOnly = false)
+{
+    auto leaf = tree.cbeginLeaf();
+    if (!leaf)  return;
+    MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+    convertPointDataGridGroup(group, tree, pointOffsets, startOffset,
+        index, filter, inCoreOnly);
 }
 
 

--- a/openvdb/points/PointConversion.h
+++ b/openvdb/points/PointConversion.h
@@ -488,7 +488,6 @@ struct ConvertPointDataGridPositionOp {
 
     void operator()(const LeafRangeT& range) const
     {
-        FilterT newFilter(mFilter);
         HandleT pHandle(mAttribute);
 
         for (auto leaf = range.begin(); leaf; ++leaf) {
@@ -508,7 +507,7 @@ struct ConvertPointDataGridPositionOp {
                 convert(iter, pHandle, *handle, offset);
             }
             else {
-                auto iter = leaf->beginIndexOn(newFilter);
+                auto iter = leaf->beginIndexOn(mFilter);
                 convert(iter, pHandle, *handle, offset);
             }
         }
@@ -577,7 +576,6 @@ struct ConvertPointDataGridAttributeOp {
 
     void operator()(const LeafRangeT& range) const
     {
-        FilterT newFilter(mFilter);
         HandleT pHandle(mAttribute);
 
         for (auto leaf = range.begin(); leaf; ++leaf) {
@@ -597,7 +595,7 @@ struct ConvertPointDataGridAttributeOp {
                 auto iter = leaf->beginIndexOn();
                 convert(iter, pHandle, *handle, offset);
             } else {
-                auto iter = leaf->beginIndexOn(newFilter);
+                auto iter = leaf->beginIndexOn(mFilter);
                 convert(iter, pHandle, *handle, offset);
             }
         }
@@ -660,8 +658,6 @@ struct ConvertPointDataGridGroupOp {
 
     void operator()(const LeafRangeT& range) const
     {
-        FilterT newFilter(mFilter);
-
         for (auto leaf = range.begin(); leaf; ++leaf) {
 
             assert(leaf.pos() < mPointOffsets.size());
@@ -681,7 +677,7 @@ struct ConvertPointDataGridGroupOp {
                 convert(iter, groupArray, offset);
             }
             else {
-                auto iter = leaf->beginIndexOn(newFilter);
+                auto iter = leaf->beginIndexOn(mFilter);
                 convert(iter, groupArray, offset);
             }
         }

--- a/openvdb/points/PointCount.h
+++ b/openvdb/points/PointCount.h
@@ -84,12 +84,11 @@ inline Index64 pointOffsets(std::vector<Index64>& pointOffsets,
 /// @brief Generate a new grid with voxel values to store the number of points per voxel
 /// @param grid             the PointDataGrid to use to compute the count grid
 /// @param filter           an optional index filter
+/// @note The return type of the grid must be an integer or floating-point scalar grid.
 template <typename PointDataGridT,
     typename GridT = typename PointDataGridT::template ValueConverter<Int32>::Type,
     typename FilterT = NullFilter>
-inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
-                                std::is_floating_point<typename GridT::ValueType>::value,
-    typename GridT::Ptr>::type
+inline typename GridT::Ptr
 pointCountGrid( const PointDataGridT& grid,
                 const FilterT& filter = NullFilter());
 
@@ -99,12 +98,11 @@ pointCountGrid( const PointDataGridT& grid,
 /// @param grid             the PointDataGrid to use to compute the count grid
 /// @param transform        the transform to use to compute the count grid
 /// @param filter           an optional index filter
+/// @note The return type of the grid must be an integer or floating-point scalar grid.
 template <typename PointDataGridT,
     typename GridT = typename PointDataGridT::template ValueConverter<Int32>::Type,
     typename FilterT = NullFilter>
-inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
-                                std::is_floating_point<typename GridT::ValueType>::value,
-    typename GridT::Ptr>::type
+inline typename GridT::Ptr
 pointCountGrid( const PointDataGridT& grid,
                 const openvdb::math::Transform& transform,
                 const FilterT& filter = NullFilter());
@@ -189,25 +187,27 @@ Index64 pointOffsets(   std::vector<Index64>& pointOffsets,
 
 
 template <typename PointDataGridT, typename GridT, typename FilterT>
-inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
-                                std::is_floating_point<typename GridT::ValueType>::value,
-    typename GridT::Ptr>::type
+typename GridT::Ptr
 pointCountGrid( const PointDataGridT& points,
                 const FilterT& filter)
 {
+    static_assert(  std::is_integral<typename GridT::ValueType>::value ||
+                    std::is_floating_point<typename GridT::ValueType>::value,
+        "openvdb::points::pointCountGrid must return an integer or floating-point scalar grid");
     return point_mask_internal::convertPointsToScalar<PointDataGridT, GridT>(
         points, filter);
 }
 
 
 template <typename PointDataGridT, typename GridT, typename FilterT>
-inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
-                                std::is_floating_point<typename GridT::ValueType>::value,
-    typename GridT::Ptr>::type
+typename GridT::Ptr
 pointCountGrid( const PointDataGridT& points,
                 const openvdb::math::Transform& transform,
                 const FilterT& filter)
 {
+    static_assert(  std::is_integral<typename GridT::ValueType>::value ||
+                    std::is_floating_point<typename GridT::ValueType>::value,
+        "openvdb::points::pointCountGrid must return an integer or floating-point scalar grid");
     return point_mask_internal::convertPointsToScalar<PointDataGridT, GridT>(
         points, transform, filter);
 }
@@ -303,9 +303,7 @@ inline Index64 getPointOffsets(std::vector<Index64>& offsets, const PointDataTre
 template <typename PointDataGridT,
     typename GridT = typename PointDataGridT::template ValueConverter<Int32>::Type>
 OPENVDB_DEPRECATED
-inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
-                                std::is_floating_point<typename GridT::ValueType>::value,
-    typename GridT::Ptr>::type
+inline typename GridT::Ptr
 pointCountGrid(const PointDataGridT& grid,
     const std::vector<Name>& includeGroups,
     const std::vector<Name>& excludeGroups)
@@ -320,9 +318,7 @@ pointCountGrid(const PointDataGridT& grid,
 template <typename PointDataGridT,
     typename GridT = typename PointDataGridT::template ValueConverter<Int32>::Type>
 OPENVDB_DEPRECATED
-inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
-                                std::is_floating_point<typename GridT::ValueType>::value,
-    typename GridT::Ptr>::type
+inline typename GridT::Ptr
 pointCountGrid(const PointDataGridT& grid,
     const openvdb::math::Transform& transform,
     const std::vector<Name>& includeGroups,

--- a/openvdb/points/PointCount.h
+++ b/openvdb/points/PointCount.h
@@ -32,7 +32,7 @@
 ///
 /// @author Dan Bailey
 ///
-/// @brief  Various point counting methods using a VDB Point Grid.
+/// @brief  Methods for counting points in VDB Point grids.
 
 #ifndef OPENVDB_POINTS_POINT_COUNT_HAS_BEEN_INCLUDED
 #define OPENVDB_POINTS_POINT_COUNT_HAS_BEEN_INCLUDED
@@ -40,12 +40,11 @@
 #include <openvdb/openvdb.h>
 
 #include "PointDataGrid.h"
-#include "PointMask.h" // GridCombinerOp
+#include "PointMask.h"
 #include "IndexFilter.h"
 
 #include <tbb/parallel_reduce.h>
 
-#include <type_traits>
 #include <vector>
 
 
@@ -55,99 +54,58 @@ namespace OPENVDB_VERSION_NAME {
 namespace points {
 
 
-/// @brief Total points in the PointDataTree
-/// @param tree PointDataTree.
-/// @param inCoreOnly if true, points in out-of-core leaf nodes are not counted
-template <typename PointDataTreeT>
-Index64 pointCount(const PointDataTreeT& tree, const bool inCoreOnly = false);
-
-
-/// @brief Total active points in the PointDataTree
-/// @param tree PointDataTree.
-/// @param inCoreOnly if true, points in out-of-core leaf nodes are not counted
-template <typename PointDataTreeT>
-Index64 activePointCount(const PointDataTreeT& tree, const bool inCoreOnly = false);
-
-
-/// @brief Total inactive points in the PointDataTree
-/// @param tree PointDataTree.
-/// @param inCoreOnly if true, points in out-of-core leaf nodes are not counted
-template <typename PointDataTreeT>
-Index64 inactivePointCount(const PointDataTreeT& tree, const bool inCoreOnly = false);
+/// @brief Count the total number of points in a PointDataTree
+/// @param tree         the PointDataTree in which to count the points
+/// @param filter       an optional index filter
+/// @param inCoreOnly   if true, points in out-of-core leaf nodes are not counted
+/// @param threaded     enable or disable threading  (threading is enabled by default)
+template <typename PointDataTreeT, typename FilterT = NullFilter>
+inline Index64 pointCount(  const PointDataTreeT& tree,
+                            const FilterT& filter = NullFilter(),
+                            const bool inCoreOnly = false);
 
 
 /// @brief Populate an array of cumulative point offsets per leaf node.
-/// @param pointOffsets     array of offsets to be populated.
-/// @param tree             PointDataTree from which to populate the offsets.
-/// @param includeGroups    the group of names to include.
-/// @param excludeGroups    the group of names to exclude.
+/// @param pointOffsets     array of offsets to be populated
+/// @param tree             the PointDataTree from which to populate the offsets
+/// @param filter           an optional index filter
 /// @param inCoreOnly       if true, points in out-of-core leaf nodes are ignored
-/// @note returns the final cumulative point offset.
-template <typename PointDataTreeT>
-Index64 getPointOffsets(std::vector<Index64>& pointOffsets, const PointDataTreeT& tree,
-                     const std::vector<Name>& includeGroups = std::vector<Name>(),
-                     const std::vector<Name>& excludeGroups = std::vector<Name>(),
-                     const bool inCoreOnly = false);
-
-
-/// @brief Total points in the group in the PointDataTree
-/// @param tree PointDataTree.
-/// @param name group name.
-/// @param inCoreOnly if true, points in out-of-core leaf nodes are not counted
-template <typename PointDataTreeT>
-Index64 groupPointCount(const PointDataTreeT& tree, const Name& name,
-    const bool inCoreOnly = false);
-
-
-/// @brief Total active points in the group in the PointDataTree
-/// @param tree PointDataTree.
-/// @param name group name.
-/// @param inCoreOnly if true, points in out-of-core leaf nodes are not counted
-template <typename PointDataTreeT>
-Index64 activeGroupPointCount(const PointDataTreeT& tree, const Name& name,
-    const bool inCoreOnly = false);
-
-
-/// @brief Total inactive points in the group in the PointDataTree
-/// @param tree PointDataTree.
-/// @param name group name.
-/// @param inCoreOnly if true, points in out-of-core leaf nodes are not counted
-template <typename PointDataTreeT>
-Index64 inactiveGroupPointCount(const PointDataTreeT& tree, const Name& name,
-    const bool inCoreOnly = false);
+/// @param threaded         enable or disable threading  (threading is enabled by default)
+/// @return The final cumulative point offset.
+template <typename PointDataTreeT, typename FilterT = NullFilter>
+inline Index64 pointOffsets(std::vector<Index64>& pointOffsets,
+                            const PointDataTreeT& tree,
+                            const FilterT& filter = NullFilter(),
+                            const bool inCoreOnly = false);
 
 
 /// @brief Generate a new grid with voxel values to store the number of points per voxel
 /// @param grid             the PointDataGrid to use to compute the count grid
-/// @param includeGroups    a vector of VDB Points groups to be included (default is all).
-/// @param excludeGroups    a vector of VDB Points groups to be excluded (default is none).
-/// @note this method is only available for integer or floating point grid types
+/// @param filter           an optional index filter
 template <typename PointDataGridT,
-    typename GridT = typename PointDataGridT::template ValueConverter<Int32>::Type>
+    typename GridT = typename PointDataGridT::template ValueConverter<Int32>::Type,
+    typename FilterT = NullFilter>
 inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
                                 std::is_floating_point<typename GridT::ValueType>::value,
     typename GridT::Ptr>::type
-pointCountGrid(const PointDataGridT& grid,
-    const std::vector<Name>& includeGroups = std::vector<Name>(),
-    const std::vector<Name>& excludeGroups = std::vector<Name>());
+pointCountGrid( const PointDataGridT& grid,
+                const FilterT& filter = NullFilter());
 
 
 /// @brief Generate a new grid that uses the supplied transform with voxel values to store the
 ///        number of points per voxel.
 /// @param grid             the PointDataGrid to use to compute the count grid
 /// @param transform        the transform to use to compute the count grid
-/// @param includeGroups    a vector of VDB Points groups to be included (default is all).
-/// @param excludeGroups    a vector of VDB Points groups to be excluded (default is none).
-/// @note this method is only available for integer or floating point grid types
+/// @param filter           an optional index filter
 template <typename PointDataGridT,
-    typename GridT = typename PointDataGridT::template ValueConverter<Int32>::Type>
+    typename GridT = typename PointDataGridT::template ValueConverter<Int32>::Type,
+    typename FilterT = NullFilter>
 inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
                                 std::is_floating_point<typename GridT::ValueType>::value,
     typename GridT::Ptr>::type
-pointCountGrid(const PointDataGridT& grid,
-    const openvdb::math::Transform& transform,
-    const std::vector<Name>& includeGroups = std::vector<Name>(),
-    const std::vector<Name>& excludeGroups = std::vector<Name>());
+pointCountGrid( const PointDataGridT& grid,
+                const openvdb::math::Transform& transform,
+                const FilterT& filter = NullFilter());
 
 
 ////////////////////////////////////////
@@ -156,7 +114,6 @@ pointCountGrid(const PointDataGridT& grid,
 namespace point_count_internal {
 
 template <  typename PointDataTreeT,
-            typename ValueIterT,
             typename FilterT>
 struct PointCountOp
 {
@@ -167,14 +124,13 @@ struct PointCountOp
         : mFilter(filter)
         , mInCoreOnly(inCoreOnly) { }
 
-    Index64 operator()(const typename LeafManagerT::LeafRange& range, Index64 size) const {
-
+    Index64 operator()(const typename LeafManagerT::LeafRange& range, Index64 size) const
+    {
         for (auto leaf = range.begin(); leaf; ++leaf) {
             if (mInCoreOnly && leaf->buffer().isOutOfCore())     continue;
-            auto iter = leaf->template beginIndex<ValueIterT, FilterT>(mFilter);
+            auto iter = leaf->template beginIndexAll<FilterT>(mFilter);
             size += iterCount(iter);
         }
-
         return size;
     }
 
@@ -188,138 +144,35 @@ private:
 }; // struct PointCountOp
 
 
-template <typename PointDataTreeT, typename FilterT, typename ValueIterT>
-Index64 threadedFilterPointCount(   const PointDataTreeT& tree,
-                                    const FilterT& filter,
-                                    const bool inCoreOnly = false)
-{
-    using PointCountOp = point_count_internal::PointCountOp< PointDataTreeT, ValueIterT, FilterT>;
-
-    typename tree::LeafManager<const PointDataTreeT> leafManager(tree);
-    const PointCountOp pointCountOp(filter, inCoreOnly);
-    return tbb::parallel_reduce(leafManager.leafRange(), Index64(0), pointCountOp, PointCountOp::join);
-}
-
-
-template <typename PointDataTreeT, typename FilterT>
-Index64 filterPointCount(const PointDataTreeT& tree,
-                         const FilterT& filter,
-                         const bool inCoreOnly = false)
-{
-    using ValueIterT = typename PointDataTreeT::LeafNodeType::ValueAllCIter;
-    return threadedFilterPointCount<  PointDataTreeT, FilterT, ValueIterT>(tree, filter, inCoreOnly);
-}
-
-
-template <typename PointDataTreeT, typename FilterT>
-Index64 filterActivePointCount( const PointDataTreeT& tree,
-                                const FilterT& filter,
-                                const bool inCoreOnly = false)
-{
-    using ValueIterT = typename PointDataTreeT::LeafNodeType::ValueOnCIter;
-    return threadedFilterPointCount<  PointDataTreeT, FilterT, ValueIterT>(tree, filter, inCoreOnly);
-}
-
-
-template <typename PointDataTreeT, typename FilterT>
-Index64 filterInactivePointCount(   const PointDataTreeT& tree,
-                                    const FilterT& filter,
-                                    const bool inCoreOnly = false)
-{
-    using ValueIterT = typename PointDataTreeT::LeafNodeType::ValueOffCIter;
-    return threadedFilterPointCount<  PointDataTreeT, FilterT, ValueIterT>(tree, filter, inCoreOnly);
-}
-
-
 } // namespace point_count_internal
 
 
 ////////////////////////////////////////
 
 
-template <typename PointDataTreeT>
-Index64 pointCount(const PointDataTreeT& tree, const bool inCoreOnly)
+template <typename PointDataTreeT, typename FilterT>
+Index64 pointCount(const PointDataTreeT& tree,
+                   const FilterT& filter,
+                   const bool inCoreOnly)
 {
     (void) inCoreOnly;
     Index64 size = 0;
     for (auto iter = tree.cbeginLeaf(); iter; ++iter) {
         if (inCoreOnly && iter->buffer().isOutOfCore())     continue;
-        size += iter->pointCount();
+        size += iterCount(iter->beginIndexAll(filter));
     }
     return size;
 }
 
 
-template <typename PointDataTreeT>
-Index64 activePointCount(const PointDataTreeT& tree, const bool inCoreOnly)
-{
-    (void) inCoreOnly;
-    Index64 size = 0;
-    for (auto iter = tree.cbeginLeaf(); iter; ++iter) {
-        if (inCoreOnly && iter->buffer().isOutOfCore())     continue;
-        size += iter->onPointCount();
-    }
-    return size;
-}
-
-
-template <typename PointDataTreeT>
-Index64 inactivePointCount(const PointDataTreeT& tree, const bool inCoreOnly)
-{
-    (void) inCoreOnly;
-    Index64 size = 0;
-    for (auto iter = tree.cbeginLeaf(); iter; ++iter) {
-        if (inCoreOnly && iter->buffer().isOutOfCore())     continue;
-        size += iter->offPointCount();
-    }
-    return size;
-}
-
-
-template <typename PointDataTreeT>
-Index64 groupPointCount(const PointDataTreeT& tree, const Name& name, const bool inCoreOnly)
-{
-    auto iter = tree.cbeginLeaf();
-    if (!iter || !iter->attributeSet().descriptor().hasGroup(name)) {
-        return Index64(0);
-    }
-    GroupFilter groupFilter(name, iter->attributeSet());
-    return point_count_internal::filterPointCount<PointDataTreeT, GroupFilter>(tree, groupFilter, inCoreOnly);
-}
-
-
-template <typename PointDataTreeT>
-Index64 activeGroupPointCount(const PointDataTreeT& tree, const Name& name, const bool inCoreOnly)
-{
-    auto iter = tree.cbeginLeaf();
-    if (!iter || !iter->attributeSet().descriptor().hasGroup(name)) {
-        return Index64(0);
-    }
-    GroupFilter groupFilter(name, iter->attributeSet());
-    return point_count_internal::filterActivePointCount<PointDataTreeT, GroupFilter>(tree, groupFilter, inCoreOnly);
-}
-
-
-template <typename PointDataTreeT>
-Index64 inactiveGroupPointCount(const PointDataTreeT& tree, const Name& name, const bool inCoreOnly)
-{
-    auto iter = tree.cbeginLeaf();
-    if (!iter || !iter->attributeSet().descriptor().hasGroup(name)) {
-        return Index64(0);
-    }
-    GroupFilter groupFilter(name, iter->attributeSet());
-    return point_count_internal::filterInactivePointCount<PointDataTreeT, GroupFilter>(tree, groupFilter, inCoreOnly);
-}
-
-
-template <typename PointDataTreeT>
-Index64 getPointOffsets(std::vector<Index64>& pointOffsets, const PointDataTreeT& tree,
-                     const std::vector<Name>& includeGroups, const std::vector<Name>& excludeGroups,
-                     const bool inCoreOnly)
+template <typename PointDataTreeT, typename FilterT>
+Index64 pointOffsets(   std::vector<Index64>& pointOffsets,
+                        const PointDataTreeT& tree,
+                        const FilterT& filter,
+                        const bool inCoreOnly)
 {
     using LeafNode = typename PointDataTreeT::LeafNodeType;
-
-    const bool useGroup = includeGroups.size() > 0 || excludeGroups.size() > 0;
+    using IndexFilterIterT = IndexIter<typename LeafNode::ValueOnCIter, FilterT>;
 
     tree::LeafManager<const PointDataTreeT> leafManager(tree);
     const size_t leafCount = leafManager.leafCount();
@@ -337,15 +190,16 @@ Index64 getPointOffsets(std::vector<Index64>& pointOffsets, const PointDataTreeT
             continue;
         }
 
-        if (useGroup) {
-            auto iter = leaf.beginValueOn();
-            MultiGroupFilter filter(includeGroups, excludeGroups, leaf.attributeSet());
-            filter.reset(leaf);
-            IndexIter<typename LeafNode::ValueOnCIter, MultiGroupFilter> filterIndexIter(iter, filter);
-            pointOffset += iterCount(filterIndexIter);
-        }
-        else {
+        auto state = filter.state(leaf);
+        if (state == index::ALL) {
             pointOffset += leaf.onPointCount();
+        }
+        else if (state != index::NONE) {
+            auto iter = leaf.beginValueOn();
+            FilterT newFilter(filter);
+            newFilter.reset(leaf);
+            IndexFilterIterT filterIndexIter(iter, newFilter);
+            pointOffset += iterCount(filterIndexIter);
         }
         pointOffsets.push_back(pointOffset);
     }
@@ -353,30 +207,150 @@ Index64 getPointOffsets(std::vector<Index64>& pointOffsets, const PointDataTreeT
 }
 
 
-template <typename PointDataGridT, typename GridT>
+template <typename PointDataGridT, typename GridT, typename FilterT>
 inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
                                 std::is_floating_point<typename GridT::ValueType>::value,
     typename GridT::Ptr>::type
-pointCountGrid(const PointDataGridT& points,
-                                   const std::vector<Name>& includeGroups,
-                                   const std::vector<Name>& excludeGroups)
+pointCountGrid( const PointDataGridT& points,
+                const FilterT& filter)
 {
     return point_mask_internal::convertPointsToScalar<PointDataGridT, GridT>(
-        points, includeGroups, excludeGroups);
+        points, filter);
 }
 
 
-template <typename PointDataGridT, typename GridT>
+template <typename PointDataGridT, typename GridT, typename FilterT>
 inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
                                 std::is_floating_point<typename GridT::ValueType>::value,
     typename GridT::Ptr>::type
-pointCountGrid(const PointDataGridT& points,
+pointCountGrid( const PointDataGridT& points,
+                const openvdb::math::Transform& transform,
+                const FilterT& filter)
+{
+    return point_mask_internal::convertPointsToScalar<PointDataGridT, GridT>(
+        points, transform, filter);
+}
+
+
+////////////////////////////////////////
+
+
+// deprecated functions
+
+
+template <typename PointDataTreeT>
+OPENVDB_DEPRECATED
+inline Index64 pointCount(const PointDataTreeT& tree, const bool inCoreOnly)
+{
+    NullFilter filter;
+    return pointCount(tree, filter, inCoreOnly);
+}
+
+
+template <typename PointDataTreeT>
+OPENVDB_DEPRECATED
+inline Index64 activePointCount(const PointDataTreeT& tree, const bool inCoreOnly = true)
+{
+    ActiveFilter filter;
+    return pointCount(tree, filter, inCoreOnly);
+}
+
+
+template <typename PointDataTreeT>
+OPENVDB_DEPRECATED
+inline Index64 inactivePointCount(const PointDataTreeT& tree, const bool inCoreOnly = true)
+{
+    InActiveFilter filter;
+    return pointCount(tree, filter, inCoreOnly);
+}
+
+
+template <typename PointDataTreeT>
+OPENVDB_DEPRECATED
+inline Index64 groupPointCount(const PointDataTreeT& tree, const Name& name,
+    const bool inCoreOnly = true)
+{
+    auto iter = tree.cbeginLeaf();
+    if (!iter || !iter->attributeSet().descriptor().hasGroup(name)) {
+        return Index64(0);
+    }
+    GroupFilter filter(name, iter->attributeSet());
+    return pointCount(tree, filter, inCoreOnly);
+}
+
+
+template <typename PointDataTreeT>
+OPENVDB_DEPRECATED
+inline Index64 activeGroupPointCount(const PointDataTreeT& tree, const Name& name,
+    const bool inCoreOnly = true)
+{
+    auto iter = tree.cbeginLeaf();
+    if (!iter || !iter->attributeSet().descriptor().hasGroup(name)) {
+        return Index64(0);
+    }
+    BinaryFilter<GroupFilter, ActiveFilter> filter(GroupFilter(name, iter->attributeSet()), ActiveFilter());
+    return pointCount(tree, filter, inCoreOnly);
+}
+
+
+template <typename PointDataTreeT>
+OPENVDB_DEPRECATED
+inline Index64 inactiveGroupPointCount(const PointDataTreeT& tree, const Name& name,
+    const bool inCoreOnly = true)
+{
+    auto iter = tree.cbeginLeaf();
+    if (!iter || !iter->attributeSet().descriptor().hasGroup(name)) {
+        return Index64(0);
+    }
+    BinaryFilter<GroupFilter, InActiveFilter> filter(GroupFilter(name, iter->attributeSet()), InActiveFilter());
+    return pointCount(tree, filter, inCoreOnly);
+}
+
+
+template <typename PointDataTreeT>
+OPENVDB_DEPRECATED
+inline Index64 getPointOffsets(std::vector<Index64>& offsets, const PointDataTreeT& tree,
+                        const std::vector<Name>& includeGroups,
+                        const std::vector<Name>& excludeGroups,
+                        const bool inCoreOnly = false)
+{
+    MultiGroupFilter filter(includeGroups, excludeGroups, tree.cbeginLeaf()->attributeSet());
+    return pointOffsets(offsets, tree, filter, inCoreOnly);
+}
+
+
+template <typename PointDataGridT,
+    typename GridT = typename PointDataGridT::template ValueConverter<Int32>::Type>
+OPENVDB_DEPRECATED
+inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
+                                std::is_floating_point<typename GridT::ValueType>::value,
+    typename GridT::Ptr>::type
+pointCountGrid(const PointDataGridT& grid,
+    const std::vector<Name>& includeGroups,
+    const std::vector<Name>& excludeGroups)
+{
+    auto leaf = grid.tree().cbeginLeaf();
+    if (!leaf)  return GridT::create(0);
+    MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+    return pointCountGrid(grid, filter);
+}
+
+
+template <typename PointDataGridT,
+    typename GridT = typename PointDataGridT::template ValueConverter<Int32>::Type>
+OPENVDB_DEPRECATED
+inline typename std::enable_if< std::is_integral<typename GridT::ValueType>::value ||
+                                std::is_floating_point<typename GridT::ValueType>::value,
+    typename GridT::Ptr>::type
+pointCountGrid(const PointDataGridT& grid,
     const openvdb::math::Transform& transform,
     const std::vector<Name>& includeGroups,
     const std::vector<Name>& excludeGroups)
 {
-    return point_mask_internal::convertPointsToScalar<PointDataGridT, GridT>(
-        points, transform, includeGroups, excludeGroups);
+    auto leaf = grid.tree().cbeginLeaf();
+    if (!leaf)  return GridT::create(0);
+    MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+    return pointCountGrid(grid, transform, filter);
 }
 
 

--- a/openvdb/points/PointCount.h
+++ b/openvdb/points/PointCount.h
@@ -124,14 +124,13 @@ Index64 pointCount(const PointDataTreeT& tree,
 
     auto countLambda =
         [&filter, &inCoreOnly] (const LeafRangeT& range, Index64 sum) -> Index64 {
-            FilterT newFilter(filter);
             for (const auto& leaf : range) {
                 if (inCoreOnly && leaf.buffer().isOutOfCore())  continue;
                 auto state = filter.state(leaf);
                 if (state == index::ALL) {
                     sum += leaf.pointCount();
                 } else if (state != index::NONE) {
-                    sum += iterCount(leaf.beginIndexAll(newFilter));
+                    sum += iterCount(leaf.beginIndexAll(filter));
                 }
             }
             return sum;
@@ -167,14 +166,12 @@ Index64 pointOffsets(   std::vector<Index64>& pointOffsets,
     LeafManagerT leafManager(tree);
     leafManager.foreach(
         [&pointOffsets, &filter, &inCoreOnly](const LeafT& leaf, size_t pos) {
-            FilterT newFilter(filter);
             if (inCoreOnly && leaf.buffer().isOutOfCore())  return;
             auto state = filter.state(leaf);
             if (state == index::ALL) {
                 pointOffsets[pos] = leaf.pointCount();
             } else if (state != index::NONE) {
-                newFilter.reset(leaf);
-                pointOffsets[pos] = iterCount(leaf.beginIndexAll(newFilter));
+                pointOffsets[pos] = iterCount(leaf.beginIndexAll(filter));
             }
         },
     threaded);

--- a/openvdb/points/PointCount.h
+++ b/openvdb/points/PointCount.h
@@ -241,7 +241,7 @@ template <typename PointDataTreeT>
 OPENVDB_DEPRECATED
 inline Index64 inactivePointCount(const PointDataTreeT& tree, const bool inCoreOnly = true)
 {
-    InActiveFilter filter;
+    InactiveFilter filter;
     return pointCount(tree, filter, inCoreOnly);
 }
 
@@ -283,7 +283,7 @@ inline Index64 inactiveGroupPointCount(const PointDataTreeT& tree, const Name& n
     if (!iter || !iter->attributeSet().descriptor().hasGroup(name)) {
         return Index64(0);
     }
-    BinaryFilter<GroupFilter, InActiveFilter> filter(GroupFilter(name, iter->attributeSet()), InActiveFilter());
+    BinaryFilter<GroupFilter, InactiveFilter> filter(GroupFilter(name, iter->attributeSet()), InactiveFilter());
     return pointCount(tree, filter, inCoreOnly);
 }
 

--- a/openvdb/points/PointDataGrid.h
+++ b/openvdb/points/PointDataGrid.h
@@ -1099,7 +1099,7 @@ template<typename T, Index Log2Dim>
 inline Index64
 PointDataLeafNode<T, Log2Dim>::pointCount() const
 {
-    return iterCount(this->beginIndexAll());
+    return this->getLastValue();
 }
 
 template<typename T, Index Log2Dim>
@@ -1128,7 +1128,11 @@ PointDataLeafNode<T, Log2Dim>::groupPointCount(const Name& groupName) const
         return Index64(0);
     }
     GroupFilter filter(groupName, this->attributeSet());
-    return iterCount(this->beginIndexAll(filter));
+    if (filter.state() == index::ALL) {
+        return this->pointCount();
+    } else {
+        return iterCount(this->beginIndexAll(filter));
+    }
 }
 
 template<typename T, Index Log2Dim>

--- a/openvdb/points/PointDataGrid.h
+++ b/openvdb/points/PointDataGrid.h
@@ -999,14 +999,16 @@ template<typename ValueIterT, typename FilterT>
 inline IndexIter<ValueIterT, FilterT>
 PointDataLeafNode<T, Log2Dim>::beginIndex(const FilterT& filter) const
 {
-    FilterT newFilter(filter);
-    newFilter.reset(*this);
-
     // generate no-op iterator if filter evaluates no indices
 
     if (filter.state() == index::NONE) {
-        return IndexIter<ValueIterT, FilterT>(ValueIterT(), newFilter);
+        return IndexIter<ValueIterT, FilterT>(ValueIterT(), filter);
     }
+
+    // copy filter to ensure thread-safety
+
+    FilterT newFilter(filter);
+    newFilter.reset(*this);
 
     using IterTraitsT = tree::IterTraits<LeafNodeType, ValueIterT>;
 

--- a/openvdb/points/PointDataGrid.h
+++ b/openvdb/points/PointDataGrid.h
@@ -999,13 +999,20 @@ template<typename ValueIterT, typename FilterT>
 inline IndexIter<ValueIterT, FilterT>
 PointDataLeafNode<T, Log2Dim>::beginIndex(const FilterT& filter) const
 {
+    FilterT newFilter(filter);
+    newFilter.reset(*this);
+
+    // generate no-op iterator if filter evaluates no indices
+
+    if (filter.state() == index::NONE) {
+        return IndexIter<ValueIterT, FilterT>(ValueIterT(), newFilter);
+    }
+
     using IterTraitsT = tree::IterTraits<LeafNodeType, ValueIterT>;
 
     // construct the value iterator and reset the filter to use this leaf
 
     ValueIterT valueIter = IterTraitsT::begin(*this);
-    FilterT newFilter(filter);
-    newFilter.reset(*this);
 
     return IndexIter<ValueIterT, FilterT>(valueIter, newFilter);
 }

--- a/openvdb/points/PointMask.h
+++ b/openvdb/points/PointMask.h
@@ -237,8 +237,6 @@ inline typename GridT::Ptr convertPointsToScalar(
 
     if (points.constTree().leafCount() == 0)            return grid;
 
-    FilterT newFilter(filter);
-
     // early exit if mask and no group logic
 
     if (std::is_same<ValueT, bool>::value && filter.state() == index::ALL) return grid;
@@ -254,9 +252,8 @@ inline typename GridT::Ptr convertPointsToScalar(
         tbb::parallel_for(leafManager.leafRange(), pointsToScalarOp);
     } else {
         // build mask from points in parallel only where filter evaluates to true
-        FilterT newFilter(filter);
         PointsToScalarOp<GridT, PointDataGridT, FilterT> pointsToScalarOp(
-            points, newFilter);
+            points, filter);
         tbb::parallel_for(leafManager.leafRange(), pointsToScalarOp);
     }
 
@@ -304,9 +301,8 @@ inline typename GridT::Ptr convertPointsToScalar(
             transform, pointsTransform, nullFilter, combiner);
         tbb::parallel_for(leafManager.leafRange(), pointsToScalarOp);
     } else {
-        FilterT newFilter(filter);
         PointsToTransformedScalarOp<GridT, PointDataGridT, FilterT> pointsToScalarOp(
-            transform, pointsTransform, newFilter, combiner);
+            transform, pointsTransform, filter, combiner);
         tbb::parallel_for(leafManager.leafRange(), pointsToScalarOp);
     }
 

--- a/openvdb/points/PointMask.h
+++ b/openvdb/points/PointMask.h
@@ -56,33 +56,31 @@ namespace points {
 
 
 /// @brief Extract a Mask Grid from a Point Data Grid
-/// @param grid             the PointDataGrid to extract the mask from.
-/// @param includeGroups    a vector of VDB Points groups to be included (default is all).
-/// @param excludeGroups    a vector of VDB Points groups to be excluded (default is none).
+/// @param grid         the PointDataGrid to extract the mask from.
+/// @param filter       an optional index filter
 /// @note this method is only available for Bool Grids and Mask Grids
 template <typename PointDataGridT,
-          typename MaskT = typename PointDataGridT::template ValueConverter<bool>::Type>
+          typename MaskT = typename PointDataGridT::template ValueConverter<bool>::Type,
+          typename FilterT = NullFilter>
 inline typename std::enable_if<std::is_same<typename MaskT::ValueType, bool>::value,
     typename MaskT::Ptr>::type
 convertPointsToMask(const PointDataGridT& grid,
-                    const std::vector<Name>& includeGroups = std::vector<Name>(),
-                    const std::vector<Name>& excludeGroups = std::vector<Name>());
+                    const FilterT& filter = NullFilter());
 
 
 /// @brief Extract a Mask Grid from a Point Data Grid using a new transform
-/// @param grid             the PointDataGrid to extract the mask from.
-/// @param transform        target transform for the mask.
-/// @param includeGroups    a vector of VDB Points groups to be included (default is all).
-/// @param excludeGroups    a vector of VDB Points groups to be excluded (default is none).
+/// @param grid         the PointDataGrid to extract the mask from.
+/// @param transform    target transform for the mask.
+/// @param filter       an optional index filter
 /// @note this method is only available for Bool Grids and Mask Grids
 template <typename PointDataGridT,
-          typename MaskT = typename PointDataGridT::template ValueConverter<bool>::Type>
+          typename MaskT = typename PointDataGridT::template ValueConverter<bool>::Type,
+          typename FilterT = NullFilter>
 inline typename std::enable_if<std::is_same<typename MaskT::ValueType, bool>::value,
     typename MaskT::Ptr>::type
 convertPointsToMask(const PointDataGridT& grid,
                     const openvdb::math::Transform& transform,
-                    const std::vector<Name>& includeGroups = std::vector<Name>(),
-                    const std::vector<Name>& excludeGroups = std::vector<Name>());
+                    const FilterT& filter = NullFilter());
 
 
 ////////////////////////////////////////
@@ -137,8 +135,8 @@ struct PointsToScalarOp
     using LeafManagerT = typename tree::LeafManager<TreeT>;
     using ValueT = typename TreeT::LeafNodeType::ValueType;
 
-    PointsToScalarOp(const PointDataGridT& grid,
-                  const FilterT& filter)
+    PointsToScalarOp(   const PointDataGridT& grid,
+                        const FilterT& filter)
         : mPointDataAccessor(grid.getConstAccessor())
         , mFilter(filter) { }
 
@@ -218,11 +216,10 @@ private:
 }; // struct PointsToTransformedScalarOp
 
 
-template<typename PointDataGridT, typename GridT>
+template<typename PointDataGridT, typename GridT, typename FilterT>
 inline typename GridT::Ptr convertPointsToScalar(
     const PointDataGridT& points,
-    const std::vector<Name>& includeGroups,
-    const std::vector<Name>& excludeGroups)
+    const FilterT& filter)
 {
     using point_mask_internal::PointsToScalarOp;
 
@@ -240,28 +237,26 @@ inline typename GridT::Ptr convertPointsToScalar(
 
     if (points.constTree().leafCount() == 0)            return grid;
 
-    const bool useGroup = !includeGroups.empty() || !excludeGroups.empty();
+    FilterT newFilter(filter);
 
     // early exit if mask and no group logic
 
-    if (std::is_same<ValueT, bool>::value && !useGroup) return grid;
+    if (std::is_same<ValueT, bool>::value && filter.state() == index::ALL) return grid;
 
     // evaluate point group filters to produce a subset of the generated mask
 
     tree::LeafManager<GridTreeT> leafManager(*tree);
 
-    if (useGroup) {
-        // build mask from points in parallel only where filter evaluates to true
-        const auto leaf = points.constTree().cbeginLeaf();
-        MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
-        PointsToScalarOp<GridT, PointDataGridT, MultiGroupFilter> pointsToScalarOp(
-            points, filter);
-        tbb::parallel_for(leafManager.leafRange(), pointsToScalarOp);
-    }
-    else {
-        NullFilter filter;
+    if (filter.state() == index::ALL) {
+        NullFilter nullFilter;
         PointsToScalarOp<GridT, PointDataGridT, NullFilter> pointsToScalarOp(
-            points, filter);
+            points, nullFilter);
+        tbb::parallel_for(leafManager.leafRange(), pointsToScalarOp);
+    } else {
+        // build mask from points in parallel only where filter evaluates to true
+        FilterT newFilter(filter);
+        PointsToScalarOp<GridT, PointDataGridT, FilterT> pointsToScalarOp(
+            points, newFilter);
         tbb::parallel_for(leafManager.leafRange(), pointsToScalarOp);
     }
 
@@ -269,12 +264,11 @@ inline typename GridT::Ptr convertPointsToScalar(
 }
 
 
-template<typename PointDataGridT, typename GridT>
+template<typename PointDataGridT, typename GridT, typename FilterT>
 inline typename GridT::Ptr convertPointsToScalar(
     const PointDataGridT& points,
     const openvdb::math::Transform& transform,
-    const std::vector<Name>& includeGroups,
-    const std::vector<Name>& excludeGroups)
+    const FilterT& filter)
 {
     using point_mask_internal::PointsToTransformedScalarOp;
     using point_mask_internal::GridCombinerOp;
@@ -288,7 +282,7 @@ inline typename GridT::Ptr convertPointsToScalar(
 
     if (transform == pointsTransform) {
         return convertPointsToScalar<PointDataGridT, GridT>(
-            points, includeGroups, excludeGroups);
+            points, filter);
     }
 
     typename GridT::Ptr grid = GridT::create();
@@ -304,19 +298,15 @@ inline typename GridT::Ptr convertPointsToScalar(
 
     tree::LeafManager<const typename PointDataGridT::TreeType> leafManager(points.tree());
 
-    const bool useGroup = !includeGroups.empty() || !excludeGroups.empty();
-
-    if (useGroup) {
-        const auto leaf = points.constTree().cbeginLeaf();
-        MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
-        PointsToTransformedScalarOp<GridT, PointDataGridT, MultiGroupFilter> pointsToScalarOp(
-            transform, pointsTransform, filter, combiner);
-        tbb::parallel_for(leafManager.leafRange(), pointsToScalarOp);
-    }
-    else {
-        NullFilter filter;
+    if (filter.state() == index::ALL) {
+        NullFilter nullFilter;
         PointsToTransformedScalarOp<GridT, PointDataGridT, NullFilter> pointsToScalarOp(
-            transform, pointsTransform, filter, combiner);
+            transform, pointsTransform, nullFilter, combiner);
+        tbb::parallel_for(leafManager.leafRange(), pointsToScalarOp);
+    } else {
+        FilterT newFilter(filter);
+        PointsToTransformedScalarOp<GridT, PointDataGridT, FilterT> pointsToScalarOp(
+            transform, pointsTransform, newFilter, combiner);
         tbb::parallel_for(leafManager.leafRange(), pointsToScalarOp);
     }
 
@@ -335,34 +325,68 @@ inline typename GridT::Ptr convertPointsToScalar(
 ////////////////////////////////////////
 
 
-template<typename PointDataGridT, typename MaskT>
+template<typename PointDataGridT, typename MaskT, typename FilterT>
 inline typename std::enable_if<std::is_same<typename MaskT::ValueType, bool>::value,
     typename MaskT::Ptr>::type
 convertPointsToMask(
     const PointDataGridT& points,
-    const std::vector<Name>& includeGroups,
-    const std::vector<Name>& excludeGroups)
+    const FilterT& filter)
 {
     return point_mask_internal::convertPointsToScalar<PointDataGridT, MaskT>(
-        points, includeGroups, excludeGroups);
+        points, filter);
 }
 
 
-template<typename PointDataGridT, typename MaskT>
+template<typename PointDataGridT, typename MaskT, typename FilterT>
 inline typename std::enable_if<std::is_same<typename MaskT::ValueType, bool>::value,
     typename MaskT::Ptr>::type
 convertPointsToMask(
     const PointDataGridT& points,
     const openvdb::math::Transform& transform,
-    const std::vector<Name>& includeGroups,
-    const std::vector<Name>& excludeGroups)
+    const FilterT& filter)
 {
     return point_mask_internal::convertPointsToScalar<PointDataGridT, MaskT>(
-        points, transform, includeGroups, excludeGroups);
+        points, transform, filter);
 }
 
 
 ////////////////////////////////////////
+
+
+// deprecated functions
+
+
+template <typename PointDataGridT,
+          typename MaskT = typename PointDataGridT::template ValueConverter<bool>::Type>
+OPENVDB_DEPRECATED
+inline typename std::enable_if<std::is_same<typename MaskT::ValueType, bool>::value,
+    typename MaskT::Ptr>::type
+convertPointsToMask(const PointDataGridT& grid,
+                    const std::vector<Name>& includeGroups,
+                    const std::vector<Name>& excludeGroups)
+{
+    auto leaf = grid.tree().cbeginLeaf();
+    if (!leaf)  return MaskT::create();
+    MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+    return convertPointsToMask(grid, filter);
+}
+
+
+template <typename PointDataGridT,
+          typename MaskT = typename PointDataGridT::template ValueConverter<bool>::Type>
+OPENVDB_DEPRECATED
+inline typename std::enable_if<std::is_same<typename MaskT::ValueType, bool>::value,
+    typename MaskT::Ptr>::type
+convertPointsToMask(const PointDataGridT& grid,
+                    const openvdb::math::Transform& transform,
+                    const std::vector<Name>& includeGroups,
+                    const std::vector<Name>& excludeGroups)
+{
+    auto leaf = grid.tree().cbeginLeaf();
+    if (!leaf)  return MaskT::create();
+    MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+    return convertPointsToMask(grid, transform, filter);
+}
 
 
 } // namespace points

--- a/openvdb/unittest/TestAttributeGroup.cc
+++ b/openvdb/unittest/TestAttributeGroup.cc
@@ -410,6 +410,7 @@ TestAttributeGroup::testAttributeGroupFilter()
     { // group values all zero
         ValueVoxelCIter indexIter(0, size);
         GroupFilter filter(zeroIndex);
+        CPPUNIT_ASSERT(filter.state() == index::PARTIAL);
         filter.reset(HandleWrapper(GroupHandle(attrGroup, 0)));
         IndexGroupAllIter iter(indexIter, filter);
 

--- a/openvdb/unittest/TestIndexFilter.cc
+++ b/openvdb/unittest/TestIndexFilter.cc
@@ -205,7 +205,7 @@ TestIndexFilter::testActiveFilter()
     CPPUNIT_ASSERT_EQUAL(Index32(2), points->tree().leafCount());
 
     ActiveFilter activeFilter;
-    InActiveFilter inActiveFilter;
+    InactiveFilter inActiveFilter;
 
     CPPUNIT_ASSERT_EQUAL(index::PARTIAL, activeFilter.state());
     CPPUNIT_ASSERT_EQUAL(index::PARTIAL, inActiveFilter.state());

--- a/openvdb/unittest/TestIndexIterator.cc
+++ b/openvdb/unittest/TestIndexIterator.cc
@@ -46,12 +46,14 @@ class TestIndexIterator: public CppUnit::TestCase
 {
 public:
     CPPUNIT_TEST_SUITE(TestIndexIterator);
+    CPPUNIT_TEST(testNullFilter);
     CPPUNIT_TEST(testValueIndexIterator);
     CPPUNIT_TEST(testFilterIndexIterator);
     CPPUNIT_TEST(testProfile);
 
     CPPUNIT_TEST_SUITE_END();
 
+    void testNullFilter();
     void testValueIndexIterator();
     void testFilterIndexIterator();
     void testProfile();
@@ -113,6 +115,17 @@ private:
 
 
 ////////////////////////////////////////
+
+
+void
+TestIndexIterator::testNullFilter()
+{
+    NullFilter filter;
+    CPPUNIT_ASSERT(filter.initialized());
+    CPPUNIT_ASSERT(filter.state() == index::ALL);
+    int a;
+    CPPUNIT_ASSERT(filter.valid(a));
+}
 
 
 void
@@ -267,6 +280,8 @@ TestIndexIterator::testValueIndexIterator()
 struct EvenIndexFilter
 {
     static bool initialized() { return true; }
+    static bool all() { return false; }
+    static bool none() { return false; }
     template <typename IterT>
     bool valid(const IterT& iter) const {
         return ((*iter) % 2) == 0;
@@ -277,6 +292,8 @@ struct EvenIndexFilter
 struct OddIndexFilter
 {
     static bool initialized() { return true; }
+    static bool all() { return false; }
+    static bool none() { return false; }
     OddIndexFilter() : mFilter() { }
     template <typename IterT>
     bool valid(const IterT& iter) const {

--- a/openvdb/unittest/TestPointConversion.cc
+++ b/openvdb/unittest/TestPointConversion.cc
@@ -372,14 +372,15 @@ TestPointConversion::testPointConversion()
     std::vector<Name> includeGroups;
     std::vector<Name> excludeGroups;
 
-    std::vector<Index64> pointOffsets;
-    getPointOffsets(pointOffsets, inputTree, includeGroups, excludeGroups);
+    std::vector<Index64> offsets;
+    MultiGroupFilter filter(includeGroups, excludeGroups, inputTree.cbeginLeaf()->attributeSet());
+    pointOffsets(offsets, inputTree, filter);
 
-    convertPointDataGridPosition(outputPosition, *pointDataGrid, pointOffsets, startOffset, includeGroups, excludeGroups);
-    convertPointDataGridAttribute(outputId, inputTree, pointOffsets, startOffset, idIndex, 1, includeGroups, excludeGroups);
-    convertPointDataGridAttribute(outputUniform, inputTree, pointOffsets, startOffset, uniformIndex, 1, includeGroups, excludeGroups);
-    convertPointDataGridAttribute(outputString, inputTree, pointOffsets, startOffset, stringIndex, 1, includeGroups, excludeGroups);
-    convertPointDataGridGroup(outputGroup, inputTree, pointOffsets, startOffset, groupIndex, includeGroups, excludeGroups);
+    convertPointDataGridPosition(outputPosition, *pointDataGrid, offsets, startOffset, filter);
+    convertPointDataGridAttribute(outputId, inputTree, offsets, startOffset, idIndex, 1, filter);
+    convertPointDataGridAttribute(outputUniform, inputTree, offsets, startOffset, uniformIndex, 1, filter);
+    convertPointDataGridAttribute(outputString, inputTree, offsets, startOffset, stringIndex, 1, filter);
+    convertPointDataGridGroup(outputGroup, inputTree, offsets, startOffset, groupIndex, filter);
 
     // pack and sort the new buffers based on id
 
@@ -420,14 +421,15 @@ TestPointConversion::testPointConversion()
 
     includeGroups.push_back("test");
 
-    pointOffsets.clear();
-    getPointOffsets(pointOffsets, inputTree, includeGroups, excludeGroups);
+    offsets.clear();
+    MultiGroupFilter filter2(includeGroups, excludeGroups, inputTree.cbeginLeaf()->attributeSet());
+    pointOffsets(offsets, inputTree, filter2);
 
-    convertPointDataGridPosition(outputPosition, *pointDataGrid, pointOffsets, startOffset, includeGroups, excludeGroups);
-    convertPointDataGridAttribute(outputId, inputTree, pointOffsets, startOffset, idIndex, /*stride*/1, includeGroups, excludeGroups);
-    convertPointDataGridAttribute(outputUniform, inputTree, pointOffsets, startOffset, uniformIndex, /*stride*/1, includeGroups, excludeGroups);
-    convertPointDataGridAttribute(outputString, inputTree, pointOffsets, startOffset, stringIndex, /*stride*/1, includeGroups, excludeGroups);
-    convertPointDataGridGroup(outputGroup, inputTree, pointOffsets, startOffset, groupIndex, includeGroups, excludeGroups);
+    convertPointDataGridPosition(outputPosition, *pointDataGrid, offsets, startOffset, filter2);
+    convertPointDataGridAttribute(outputId, inputTree, offsets, startOffset, idIndex, /*stride*/1, filter2);
+    convertPointDataGridAttribute(outputUniform, inputTree, offsets, startOffset, uniformIndex, /*stride*/1, filter2);
+    convertPointDataGridAttribute(outputString, inputTree, offsets, startOffset, stringIndex, /*stride*/1, filter2);
+    convertPointDataGridGroup(outputGroup, inputTree, offsets, startOffset, groupIndex, filter2);
 
     CPPUNIT_ASSERT_EQUAL(size_t(outputPosition.size() - startOffset), size_t(halfCount));
     CPPUNIT_ASSERT_EQUAL(size_t(outputId.size() - startOffset), size_t(halfCount));
@@ -538,12 +540,12 @@ TestPointConversion::testStride()
     outputXyz.resize((startOffset + id.size())*3);
     outputId.resize(startOffset + id.size());
 
-    std::vector<Index64> pointOffsets;
-    getPointOffsets(pointOffsets, tree);
+    std::vector<Index64> offsets;
+    pointOffsets(offsets, tree);
 
-    convertPointDataGridPosition(outputPosition, *pointDataGrid, pointOffsets, startOffset);
-    convertPointDataGridAttribute(outputId, tree, pointOffsets, startOffset, idIndex);
-    convertPointDataGridAttribute(outputXyz, tree, pointOffsets, startOffset, xyzIndex, /*stride=*/3);
+    convertPointDataGridPosition(outputPosition, *pointDataGrid, offsets, startOffset);
+    convertPointDataGridAttribute(outputId, tree, offsets, startOffset, idIndex);
+    convertPointDataGridAttribute(outputXyz, tree, offsets, startOffset, xyzIndex, /*stride=*/3);
 
     // pack and sort the new buffers based on id
 

--- a/openvdb/unittest/TestPointCount.cc
+++ b/openvdb/unittest/TestPointCount.cc
@@ -162,7 +162,7 @@ TestPointCount::testCount()
 
     CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(LeafType::SIZE - 1));
     CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(LeafType::SIZE - 1));
-    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(0));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InactiveFilter()), Index64(0));
 
     // manually de-activate two voxels
 
@@ -175,7 +175,7 @@ TestPointCount::testCount()
 
     CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(LeafType::SIZE - 1));
     CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(LeafType::SIZE - 3));
-    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(2));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InactiveFilter()), Index64(2));
 
     // one point per every other voxel and de-activate empty voxels
 
@@ -194,7 +194,7 @@ TestPointCount::testCount()
 
     CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(LeafType::SIZE / 2));
     CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(LeafType::SIZE / 2));
-    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(0));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InactiveFilter()), Index64(0));
 
     // add a new non-empty leaf and check totalPointCount is correct
 
@@ -209,7 +209,7 @@ TestPointCount::testCount()
 
     CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(LeafType::SIZE / 2 + LeafType::SIZE - 1));
     CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(LeafType::SIZE / 2 + LeafType::SIZE - 1));
-    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(0));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InactiveFilter()), Index64(0));
 }
 
 
@@ -265,7 +265,7 @@ TestPointCount::testGroup()
 
         CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(4));
         CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(4));
-        CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(0));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, InactiveFilter()), Index64(0));
         CPPUNIT_ASSERT_EQUAL(leafIter->pointCount(), Index64(4));
         CPPUNIT_ASSERT_EQUAL(leafIter->onPointCount(), Index64(4));
         CPPUNIT_ASSERT_EQUAL(leafIter->offPointCount(), Index64(0));
@@ -301,8 +301,8 @@ TestPointCount::testGroup()
         {
             CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, ActiveFilter>(
                 groupFilter, ActiveFilter())), Index64(2));
-            CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, InActiveFilter>(
-                groupFilter, InActiveFilter())), Index64(0));
+            CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, InactiveFilter>(
+                groupFilter, InactiveFilter())), Index64(0));
         }
 
         CPPUNIT_ASSERT_NO_THROW(leafIter->validateOffsets());
@@ -339,12 +339,12 @@ TestPointCount::testGroup()
         CPPUNIT_ASSERT_EQUAL(leafIter->groupPointCount("test"), Index64(2));
         CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, ActiveFilter>(
             groupFilter, ActiveFilter())), Index64(1));
-        CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, InActiveFilter>(
-            groupFilter, InActiveFilter())), Index64(1));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, InactiveFilter>(
+            groupFilter, InactiveFilter())), Index64(1));
 
         CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(4));
         CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(3));
-        CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(1));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, InactiveFilter()), Index64(1));
 
         // write out grid to a temp file
         {
@@ -382,33 +382,33 @@ TestPointCount::testGroup()
 #if OPENVDB_ABI_VERSION_NUMBER >= 3
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, NullFilter(), inCoreOnly), Index64(0));
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, ActiveFilter(), inCoreOnly), Index64(0));
-            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, InActiveFilter(), inCoreOnly), Index64(0));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, InactiveFilter(), inCoreOnly), Index64(0));
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, groupFilter, inCoreOnly), Index64(0));
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, ActiveFilter>(
                 groupFilter, ActiveFilter()), inCoreOnly), Index64(0));
-            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, InActiveFilter>(
-                groupFilter, InActiveFilter()), inCoreOnly), Index64(0));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, InactiveFilter>(
+                groupFilter, InactiveFilter()), inCoreOnly), Index64(0));
 #else
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, NullFilter(), inCoreOnly), Index64(4));
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, ActiveFilter(), inCoreOnly), Index64(3));
-            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, InActiveFilter(), inCoreOnly), Index64(1));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, InactiveFilter(), inCoreOnly), Index64(1));
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, groupFilter, inCoreOnly), Index64(2));
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, ActiveFilter>(
                 groupFilter, ActiveFilter()), inCoreOnly), Index64(1));
-            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, InActiveFilter>(
-                groupFilter, InActiveFilter()), inCoreOnly), Index64(1));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, InactiveFilter>(
+                groupFilter, InactiveFilter()), inCoreOnly), Index64(1));
 #endif
 
             inCoreOnly = false;
 
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, NullFilter(), inCoreOnly), Index64(4));
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, ActiveFilter(), inCoreOnly), Index64(3));
-            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, InActiveFilter(), inCoreOnly), Index64(1));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, InactiveFilter(), inCoreOnly), Index64(1));
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, groupFilter, inCoreOnly), Index64(2));
             CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, ActiveFilter>(
                 groupFilter, ActiveFilter()), inCoreOnly), Index64(1));
-            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, InActiveFilter>(
-                groupFilter, InActiveFilter()), inCoreOnly), Index64(1));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, InactiveFilter>(
+                groupFilter, InactiveFilter()), inCoreOnly), Index64(1));
         }
 
         // update the value mask and confirm point counts once again
@@ -423,12 +423,12 @@ TestPointCount::testGroup()
         CPPUNIT_ASSERT_EQUAL(leafIter->groupPointCount("test"), Index64(2));
         CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, ActiveFilter>(
             groupFilter, ActiveFilter())), Index64(2));
-        CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, InActiveFilter>(
-            groupFilter, InActiveFilter())), Index64(0));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, InactiveFilter>(
+            groupFilter, InactiveFilter())), Index64(0));
 
         CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(4));
         CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(4));
-        CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(0));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, InactiveFilter()), Index64(0));
     }
 
     // create a tree with multiple leaves

--- a/openvdb/unittest/TestPointCount.cc
+++ b/openvdb/unittest/TestPointCount.cc
@@ -161,8 +161,8 @@ TestPointCount::testCount()
     CPPUNIT_ASSERT_EQUAL(leaf.offPointCount(), Index64(0));
 
     CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(LeafType::SIZE - 1));
-    CPPUNIT_ASSERT_EQUAL(activePointCount(tree), Index64(LeafType::SIZE - 1));
-    CPPUNIT_ASSERT_EQUAL(inactivePointCount(tree), Index64(0));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(LeafType::SIZE - 1));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(0));
 
     // manually de-activate two voxels
 
@@ -174,8 +174,8 @@ TestPointCount::testCount()
     CPPUNIT_ASSERT_EQUAL(leaf.offPointCount(), Index64(2));
 
     CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(LeafType::SIZE - 1));
-    CPPUNIT_ASSERT_EQUAL(activePointCount(tree), Index64(LeafType::SIZE - 3));
-    CPPUNIT_ASSERT_EQUAL(inactivePointCount(tree), Index64(2));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(LeafType::SIZE - 3));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(2));
 
     // one point per every other voxel and de-activate empty voxels
 
@@ -193,8 +193,8 @@ TestPointCount::testCount()
     CPPUNIT_ASSERT_EQUAL(leaf.offPointCount(), Index64(0));
 
     CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(LeafType::SIZE / 2));
-    CPPUNIT_ASSERT_EQUAL(activePointCount(tree), Index64(LeafType::SIZE / 2));
-    CPPUNIT_ASSERT_EQUAL(inactivePointCount(tree), Index64(0));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(LeafType::SIZE / 2));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(0));
 
     // add a new non-empty leaf and check totalPointCount is correct
 
@@ -208,8 +208,8 @@ TestPointCount::testCount()
     }
 
     CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(LeafType::SIZE / 2 + LeafType::SIZE - 1));
-    CPPUNIT_ASSERT_EQUAL(activePointCount(tree), Index64(LeafType::SIZE / 2 + LeafType::SIZE - 1));
-    CPPUNIT_ASSERT_EQUAL(inactivePointCount(tree), Index64(0));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(LeafType::SIZE / 2 + LeafType::SIZE - 1));
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(0));
 }
 
 
@@ -264,15 +264,15 @@ TestPointCount::testGroup()
         CPPUNIT_ASSERT_EQUAL(attributeSet.descriptor().groupMap().size(), size_t(1));
 
         CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(4));
-        CPPUNIT_ASSERT_EQUAL(activePointCount(tree), Index64(4));
-        CPPUNIT_ASSERT_EQUAL(inactivePointCount(tree), Index64(0));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(4));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(0));
         CPPUNIT_ASSERT_EQUAL(leafIter->pointCount(), Index64(4));
         CPPUNIT_ASSERT_EQUAL(leafIter->onPointCount(), Index64(4));
         CPPUNIT_ASSERT_EQUAL(leafIter->offPointCount(), Index64(0));
 
         // no points found when filtered by the empty group
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "test"), Index64(0));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, GroupFilter("test", attributeSet)), Index64(0));
         CPPUNIT_ASSERT_EQUAL(leafIter->groupPointCount("test"), Index64(0));
     }
 
@@ -293,12 +293,16 @@ TestPointCount::testGroup()
 
         // only two out of four points should be found when group filtered
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "test"), Index64(2));
+        GroupFilter groupFilter("test", attributeSet);
+
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, GroupFilter("test", attributeSet)), Index64(2));
         CPPUNIT_ASSERT_EQUAL(leafIter->groupPointCount("test"), Index64(2));
 
         {
-            CPPUNIT_ASSERT_EQUAL(activeGroupPointCount(tree, "test"), Index64(2));
-            CPPUNIT_ASSERT_EQUAL(inactiveGroupPointCount(tree, "test"), Index64(0));
+            CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, ActiveFilter>(
+                groupFilter, ActiveFilter())), Index64(2));
+            CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, InActiveFilter>(
+                groupFilter, InActiveFilter())), Index64(0));
         }
 
         CPPUNIT_ASSERT_NO_THROW(leafIter->validateOffsets());
@@ -331,14 +335,16 @@ TestPointCount::testGroup()
 
         // ensure active / inactive point counts are correct
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "test"), Index64(2));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, GroupFilter("test", attributeSet)), Index64(2));
         CPPUNIT_ASSERT_EQUAL(leafIter->groupPointCount("test"), Index64(2));
-        CPPUNIT_ASSERT_EQUAL(activeGroupPointCount(tree, "test"), Index64(1));
-        CPPUNIT_ASSERT_EQUAL(inactiveGroupPointCount(tree, "test"), Index64(1));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, ActiveFilter>(
+            groupFilter, ActiveFilter())), Index64(1));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, InActiveFilter>(
+            groupFilter, InActiveFilter())), Index64(1));
 
         CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(4));
-        CPPUNIT_ASSERT_EQUAL(activePointCount(tree), Index64(3));
-        CPPUNIT_ASSERT_EQUAL(inactivePointCount(tree), Index64(1));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(3));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(1));
 
         // write out grid to a temp file
         {
@@ -367,29 +373,42 @@ TestPointCount::testGroup()
             CPPUNIT_ASSERT(inputGrid);
 
             PointDataTree& inputTree = inputGrid->tree();
+            const auto& attributeSet = inputTree.cbeginLeaf()->attributeSet();
+
+            GroupFilter groupFilter("test", attributeSet);
+
+            bool inCoreOnly = true;
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 3
-            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, /*inCoreOnly=*/true), Index64(0));
-            CPPUNIT_ASSERT_EQUAL(activePointCount(inputTree, /*inCoreOnly=*/true), Index64(0));
-            CPPUNIT_ASSERT_EQUAL(inactivePointCount(inputTree, /*inCoreOnly=*/true), Index64(0));
-            CPPUNIT_ASSERT_EQUAL(groupPointCount(inputTree, "test", /*inCoreOnly=*/true), Index64(0));
-            CPPUNIT_ASSERT_EQUAL(activeGroupPointCount(inputTree, "test", /*inCoreOnly=*/true), Index64(0));
-            CPPUNIT_ASSERT_EQUAL(inactiveGroupPointCount(inputTree, "test", /*inCoreOnly=*/true), Index64(0));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, NullFilter(), inCoreOnly), Index64(0));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, ActiveFilter(), inCoreOnly), Index64(0));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, InActiveFilter(), inCoreOnly), Index64(0));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, groupFilter, inCoreOnly), Index64(0));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, ActiveFilter>(
+                groupFilter, ActiveFilter()), inCoreOnly), Index64(0));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, InActiveFilter>(
+                groupFilter, InActiveFilter()), inCoreOnly), Index64(0));
 #else
-            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, /*inCoreOnly=*/true), Index64(4));
-            CPPUNIT_ASSERT_EQUAL(activePointCount(inputTree, /*inCoreOnly=*/true), Index64(3));
-            CPPUNIT_ASSERT_EQUAL(inactivePointCount(inputTree, /*inCoreOnly=*/true), Index64(1));
-            CPPUNIT_ASSERT_EQUAL(groupPointCount(inputTree, "test", /*inCoreOnly=*/true), Index64(2));
-            CPPUNIT_ASSERT_EQUAL(activeGroupPointCount(inputTree, "test", /*inCoreOnly=*/true), Index64(1));
-            CPPUNIT_ASSERT_EQUAL(inactiveGroupPointCount(inputTree, "test", /*inCoreOnly=*/true), Index64(1));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, NullFilter(), inCoreOnly), Index64(4));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, ActiveFilter(), inCoreOnly), Index64(3));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, InActiveFilter(), inCoreOnly), Index64(1));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, groupFilter, inCoreOnly), Index64(2));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, ActiveFilter>(
+                groupFilter, ActiveFilter()), inCoreOnly), Index64(1));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, InActiveFilter>(
+                groupFilter, InActiveFilter()), inCoreOnly), Index64(1));
 #endif
 
-            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, /*inCoreOnly=*/false), Index64(4));
-            CPPUNIT_ASSERT_EQUAL(activePointCount(inputTree, /*inCoreOnly=*/false), Index64(3));
-            CPPUNIT_ASSERT_EQUAL(inactivePointCount(inputTree, /*inCoreOnly=*/false), Index64(1));
-            CPPUNIT_ASSERT_EQUAL(groupPointCount(inputTree, "test", /*inCoreOnly=*/false), Index64(2));
-            CPPUNIT_ASSERT_EQUAL(activeGroupPointCount(inputTree, "test", /*inCoreOnly=*/false), Index64(1));
-            CPPUNIT_ASSERT_EQUAL(inactiveGroupPointCount(inputTree, "test", /*inCoreOnly=*/false), Index64(1));
+            inCoreOnly = false;
+
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, NullFilter(), inCoreOnly), Index64(4));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, ActiveFilter(), inCoreOnly), Index64(3));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, InActiveFilter(), inCoreOnly), Index64(1));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, groupFilter, inCoreOnly), Index64(2));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, ActiveFilter>(
+                groupFilter, ActiveFilter()), inCoreOnly), Index64(1));
+            CPPUNIT_ASSERT_EQUAL(pointCount(inputTree, BinaryFilter<GroupFilter, InActiveFilter>(
+                groupFilter, InActiveFilter()), inCoreOnly), Index64(1));
         }
 
         // update the value mask and confirm point counts once again
@@ -398,14 +417,18 @@ TestPointCount::testGroup()
 
         CPPUNIT_ASSERT_NO_THROW(leafIter->validateOffsets());
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "test"), Index64(2));
+        auto& attributeSet = tree.cbeginLeaf()->attributeSet();
+
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, GroupFilter("test", attributeSet)), Index64(2));
         CPPUNIT_ASSERT_EQUAL(leafIter->groupPointCount("test"), Index64(2));
-        CPPUNIT_ASSERT_EQUAL(activeGroupPointCount(tree, "test"), Index64(2));
-        CPPUNIT_ASSERT_EQUAL(inactiveGroupPointCount(tree, "test"), Index64(0));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, ActiveFilter>(
+            groupFilter, ActiveFilter())), Index64(2));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, BinaryFilter<GroupFilter, InActiveFilter>(
+            groupFilter, InActiveFilter())), Index64(0));
 
         CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(4));
-        CPPUNIT_ASSERT_EQUAL(activePointCount(tree), Index64(4));
-        CPPUNIT_ASSERT_EQUAL(inactivePointCount(tree), Index64(0));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, ActiveFilter()), Index64(4));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, InActiveFilter()), Index64(0));
     }
 
     // create a tree with multiple leaves
@@ -424,10 +447,11 @@ TestPointCount::testGroup()
     appendGroup(tree2, "test");
 
     { // assign two points to the group
-        const Descriptor::GroupIndex index = leafIter->attributeSet().groupIndex("test");
+        const auto& attributeSet = leafIter->attributeSet();
+        const Descriptor::GroupIndex index = attributeSet.groupIndex("test");
 
         CPPUNIT_ASSERT(index.first != AttributeSet::INVALID_POS);
-        CPPUNIT_ASSERT(index.first < leafIter->attributeSet().size());
+        CPPUNIT_ASSERT(index.first < attributeSet.size());
 
         AttributeArray& array = leafIter->attributeArray(index.first);
 
@@ -438,7 +462,7 @@ TestPointCount::testGroup()
         groupArray.set(0, GroupType(1) << index.second);
         groupArray.set(3, GroupType(1) << index.second);
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree2, "test"), Index64(2));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree2, GroupFilter("test", attributeSet)), Index64(2));
         CPPUNIT_ASSERT_EQUAL(leafIter->groupPointCount("test"), Index64(2));
         CPPUNIT_ASSERT_EQUAL(pointCount(tree2), Index64(7));
     }
@@ -448,7 +472,8 @@ TestPointCount::testGroup()
     CPPUNIT_ASSERT(leafIter);
 
     { // assign another point to the group in a different leaf
-        const Descriptor::GroupIndex index = leafIter->attributeSet().groupIndex("test");
+        const auto& attributeSet = leafIter->attributeSet();
+        const Descriptor::GroupIndex index = attributeSet.groupIndex("test");
 
         CPPUNIT_ASSERT(index.first != AttributeSet::INVALID_POS);
         CPPUNIT_ASSERT(index.first < leafIter->attributeSet().size());
@@ -461,7 +486,7 @@ TestPointCount::testGroup()
 
         groupArray.set(0, GroupType(1) << index.second);
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree2, "test"), Index64(3));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree2, GroupFilter("test", attributeSet)), Index64(3));
         CPPUNIT_ASSERT_EQUAL(leafIter->groupPointCount("test"), Index64(1));
         CPPUNIT_ASSERT_EQUAL(pointCount(tree2), Index64(7));
     }
@@ -484,31 +509,32 @@ TestPointCount::testOffsets()
     PointDataTree& tree = grid->tree();
 
     { // all point offsets
-        std::vector<Index64> pointOffsets;
-        Index64 total = getPointOffsets(pointOffsets, tree);
+        std::vector<Index64> offsets;
+        Index64 total = pointOffsets(offsets, tree);
 
-        CPPUNIT_ASSERT_EQUAL(pointOffsets.size(), size_t(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[0], Index64(1));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[1], Index64(3));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[2], Index64(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[3], Index64(5));
+        CPPUNIT_ASSERT_EQUAL(offsets.size(), size_t(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[0], Index64(1));
+        CPPUNIT_ASSERT_EQUAL(offsets[1], Index64(3));
+        CPPUNIT_ASSERT_EQUAL(offsets[2], Index64(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[3], Index64(5));
         CPPUNIT_ASSERT_EQUAL(total, Index64(5));
     }
 
     { // all point offsets when using a non-existant exclude group
 
-        std::vector<Index64> pointOffsets;
+        std::vector<Index64> offsets;
 
         std::vector<Name> includeGroups;
         std::vector<Name> excludeGroups{"empty"};
 
-        Index64 total = getPointOffsets(pointOffsets, tree, includeGroups, excludeGroups);
+        MultiGroupFilter filter(includeGroups, excludeGroups, tree.cbeginLeaf()->attributeSet());
+        Index64 total = pointOffsets(offsets, tree, filter);
 
-        CPPUNIT_ASSERT_EQUAL(pointOffsets.size(), size_t(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[0], Index64(1));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[1], Index64(3));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[2], Index64(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[3], Index64(5));
+        CPPUNIT_ASSERT_EQUAL(offsets.size(), size_t(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[0], Index64(1));
+        CPPUNIT_ASSERT_EQUAL(offsets[1], Index64(3));
+        CPPUNIT_ASSERT_EQUAL(offsets[2], Index64(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[3], Index64(5));
         CPPUNIT_ASSERT_EQUAL(total, Index64(5));
     }
 
@@ -521,34 +547,36 @@ TestPointCount::testOffsets()
     groupHandle.set(0, true);
 
     { // include this group
-        std::vector<Index64> pointOffsets;
+        std::vector<Index64> offsets;
 
         std::vector<Name> includeGroups{"test"};
         std::vector<Name> excludeGroups;
 
-        Index64 total = getPointOffsets(pointOffsets, tree, includeGroups, excludeGroups);
+        MultiGroupFilter filter(includeGroups, excludeGroups, tree.cbeginLeaf()->attributeSet());
+        Index64 total = pointOffsets(offsets, tree, filter);
 
-        CPPUNIT_ASSERT_EQUAL(pointOffsets.size(), size_t(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[0], Index64(0));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[1], Index64(1));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[2], Index64(1));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[3], Index64(1));
+        CPPUNIT_ASSERT_EQUAL(offsets.size(), size_t(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[0], Index64(0));
+        CPPUNIT_ASSERT_EQUAL(offsets[1], Index64(1));
+        CPPUNIT_ASSERT_EQUAL(offsets[2], Index64(1));
+        CPPUNIT_ASSERT_EQUAL(offsets[3], Index64(1));
         CPPUNIT_ASSERT_EQUAL(total, Index64(1));
     }
 
     { // exclude this group
-        std::vector<Index64> pointOffsets;
+        std::vector<Index64> offsets;
 
         std::vector<Name> includeGroups;
         std::vector<Name> excludeGroups{"test"};
 
-        Index64 total = getPointOffsets(pointOffsets, tree, includeGroups, excludeGroups);
+        MultiGroupFilter filter(includeGroups, excludeGroups, tree.cbeginLeaf()->attributeSet());
+        Index64 total = pointOffsets(offsets, tree, filter);
 
-        CPPUNIT_ASSERT_EQUAL(pointOffsets.size(), size_t(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[0], Index64(1));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[1], Index64(2));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[2], Index64(3));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[3], Index64(4));
+        CPPUNIT_ASSERT_EQUAL(offsets.size(), size_t(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[0], Index64(1));
+        CPPUNIT_ASSERT_EQUAL(offsets[1], Index64(2));
+        CPPUNIT_ASSERT_EQUAL(offsets[2], Index64(3));
+        CPPUNIT_ASSERT_EQUAL(offsets[3], Index64(4));
         CPPUNIT_ASSERT_EQUAL(total, Index64(4));
     }
 
@@ -597,37 +625,38 @@ TestPointCount::testOffsets()
 
         PointDataTree& inputTree = inputGrid->tree();
 
-        std::vector<Index64> pointOffsets;
+        std::vector<Index64> offsets;
         std::vector<Name> includeGroups;
         std::vector<Name> excludeGroups;
 
-        Index64 total = getPointOffsets(pointOffsets, inputTree, includeGroups, excludeGroups, /*inCoreOnly=*/true);
+        MultiGroupFilter filter(includeGroups, excludeGroups, inputTree.cbeginLeaf()->attributeSet());
+        Index64 total = pointOffsets(offsets, inputTree, filter, /*inCoreOnly=*/true);
 
 #if OPENVDB_ABI_VERSION_NUMBER >= 3
-        CPPUNIT_ASSERT_EQUAL(pointOffsets.size(), size_t(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[0], Index64(0));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[1], Index64(0));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[2], Index64(0));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[3], Index64(0));
+        CPPUNIT_ASSERT_EQUAL(offsets.size(), size_t(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[0], Index64(0));
+        CPPUNIT_ASSERT_EQUAL(offsets[1], Index64(0));
+        CPPUNIT_ASSERT_EQUAL(offsets[2], Index64(0));
+        CPPUNIT_ASSERT_EQUAL(offsets[3], Index64(0));
         CPPUNIT_ASSERT_EQUAL(total, Index64(0));
 #else
-        CPPUNIT_ASSERT_EQUAL(pointOffsets.size(), size_t(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[0], Index64(1));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[1], Index64(3));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[2], Index64(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[3], Index64(5));
+        CPPUNIT_ASSERT_EQUAL(offsets.size(), size_t(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[0], Index64(1));
+        CPPUNIT_ASSERT_EQUAL(offsets[1], Index64(3));
+        CPPUNIT_ASSERT_EQUAL(offsets[2], Index64(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[3], Index64(5));
         CPPUNIT_ASSERT_EQUAL(total, Index64(5));
 #endif
 
-        pointOffsets.clear();
+        offsets.clear();
 
-        total = getPointOffsets(pointOffsets, inputTree, includeGroups, excludeGroups, /*inCoreOnly=*/false);
+        total = pointOffsets(offsets, inputTree, filter, /*inCoreOnly=*/false);
 
-        CPPUNIT_ASSERT_EQUAL(pointOffsets.size(), size_t(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[0], Index64(1));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[1], Index64(3));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[2], Index64(4));
-        CPPUNIT_ASSERT_EQUAL(pointOffsets[3], Index64(5));
+        CPPUNIT_ASSERT_EQUAL(offsets.size(), size_t(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[0], Index64(1));
+        CPPUNIT_ASSERT_EQUAL(offsets[1], Index64(3));
+        CPPUNIT_ASSERT_EQUAL(offsets[2], Index64(4));
+        CPPUNIT_ASSERT_EQUAL(offsets[3], Index64(5));
         CPPUNIT_ASSERT_EQUAL(total, Index64(5));
     }
     std::remove(filename.c_str());
@@ -782,31 +811,35 @@ TestPointCount::testCountGrid()
                     createPointDataGrid<NullCodec, PointDataGrid>(*pointIndexGrid,
                                                                   pointList, *transform);
 
+            auto& tree = points->tree();
+
             // assign point 3 to new group "test"
 
-            appendGroup(points->tree(), "test");
+            appendGroup(tree, "test");
 
             std::vector<short> groups{0,0,1,0,0};
 
-            setGroup(points->tree(), pointIndexGrid->tree(), groups, "test");
+            setGroup(tree, pointIndexGrid->tree(), groups, "test");
 
             std::vector<std::string> includeGroups{"test"};
             std::vector<std::string> excludeGroups;
 
             // generate a count grid with the same transform
 
-            Int32Grid::Ptr count = pointCountGrid(*points, includeGroups, excludeGroups);
+            MultiGroupFilter filter(includeGroups, excludeGroups,
+                tree.cbeginLeaf()->attributeSet());
+            Int32Grid::Ptr count = pointCountGrid(*points, filter);
 
             CPPUNIT_ASSERT_EQUAL(count->activeVoxelCount(), Index64(1));
             CPPUNIT_ASSERT_EQUAL(voxelSum(*count), Index64(1));
 
-            count = pointCountGrid(*points, excludeGroups, includeGroups);
+            MultiGroupFilter filter2(excludeGroups, includeGroups,
+                tree.cbeginLeaf()->attributeSet());
+            count = pointCountGrid(*points, filter2);
 
             CPPUNIT_ASSERT_EQUAL(count->activeVoxelCount(), Index64(4));
             CPPUNIT_ASSERT_EQUAL(voxelSum(*count), Index64(4));
         }
-
-        // TODO: test include and exclude groups
     }
 
     { // 40,000 points on a unit sphere

--- a/openvdb/unittest/TestPointGroup.cc
+++ b/openvdb/unittest/TestPointGroup.cc
@@ -79,6 +79,10 @@ class FirstFilter
 public:
     static bool initialized() { return true; }
 
+    static index::State state() { return index::PARTIAL; }
+    template <typename LeafT>
+    static index::State state(const LeafT&) { return index::PARTIAL; }
+
     template <typename LeafT> void reset(const LeafT&) { }
 
     template <typename IterT> bool valid(const IterT& iter) const
@@ -271,11 +275,12 @@ TestPointGroup::testAppendDrop()
 
         setGroup(tree, "test", true);
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "test"), Index64(4));
+        GroupFilter filter("test", tree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, filter), Index64(4));
 
         setGroup(tree, "test", false);
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "test"), Index64(0));
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, filter), Index64(0));
 
         dropGroup(tree, "test");
     }
@@ -307,7 +312,8 @@ TestPointGroup::testAppendDrop()
         // has empty membership
 
         CPPUNIT_ASSERT(newTree.cbeginLeaf());
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(newTree, "test"), Index64(0));
+        GroupFilter filter("test", newTree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(newTree, filter), Index64(0));
 
         // check that membership in a group that was not created with a
         // new attribute array is still empty.
@@ -324,7 +330,8 @@ TestPointGroup::testAppendDrop()
         test2Handle.set(0, true);
         test2Handle.set(2, true);
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(newTree, "test2"), Index64(2));
+        GroupFilter filter2("test2", newTree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(newTree, filter2), Index64(2));
 
         // drop and re-add group
 
@@ -333,7 +340,7 @@ TestPointGroup::testAppendDrop()
 
         // check that group is fully cleared and does not have previously existing data
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(newTree, "test2"), Index64(0));
+        CPPUNIT_ASSERT_EQUAL(pointCount(newTree, filter2), Index64(0));
     }
 
 }
@@ -465,7 +472,8 @@ TestPointGroup::testSet()
     appendGroup(tree, "test");
 
     CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(6));
-    CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "test"), Index64(0));
+    GroupFilter filter("test", tree.cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, filter), Index64(0));
 
     std::vector<short> membership{1, 0, 1, 1, 0, 1};
 
@@ -484,7 +492,8 @@ TestPointGroup::testSet()
     dropGroup(tree2, "copy1");
 
     CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(6));
-    CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "test"), Index64(4));
+    GroupFilter filter2("test", tree.cbeginLeaf()->attributeSet());
+    CPPUNIT_ASSERT_EQUAL(pointCount(tree, filter2), Index64(4));
 
     { // IO
         // setup temp directory
@@ -539,7 +548,8 @@ TestPointGroup::testSet()
             CPPUNIT_ASSERT_EQUAL(descriptor.groupMap().size(), size_t(1));
 
             CPPUNIT_ASSERT_EQUAL(pointCount(treex), Index64(6));
-            CPPUNIT_ASSERT_EQUAL(groupPointCount(treex, "test"), Index64(4));
+            GroupFilter filter2("test", leaf.attributeSet());
+            CPPUNIT_ASSERT_EQUAL(pointCount(treex, filter2), Index64(4));
         }
         std::remove(filename.c_str());
     }
@@ -577,11 +587,12 @@ TestPointGroup::testFilter()
         appendGroup(tree, "first");
 
         CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(6));
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "first"), Index64(0));
+        GroupFilter filter("first", tree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, filter), Index64(0));
 
-        FirstFilter filter;
+        FirstFilter filter2;
 
-        setGroupByFilter<PointDataTree, FirstFilter>(tree, "first", filter);
+        setGroupByFilter<PointDataTree, FirstFilter>(tree, "first", filter2);
 
         auto iter = tree.cbeginLeaf();
 
@@ -589,7 +600,8 @@ TestPointGroup::testFilter()
             CPPUNIT_ASSERT_EQUAL(iter->groupPointCount("first"), Index64(1));
         }
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "first"), Index64(2));
+        GroupFilter filter3("first", tree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, filter3), Index64(2));
     }
 
     const openvdb::BBoxd bbox(openvdb::Vec3d(0, 1.5, 0), openvdb::Vec3d(101, 100.5, 101));
@@ -598,30 +610,34 @@ TestPointGroup::testFilter()
         appendGroup(tree, "bbox");
 
         CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(6));
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "bbox"), Index64(0));
+        GroupFilter filter("bbox", tree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, filter), Index64(0));
 
-        BBoxFilter filter(*transform, bbox);
+        BBoxFilter filter2(*transform, bbox);
 
-        setGroupByFilter<PointDataTree, BBoxFilter>(tree, "bbox", filter);
+        setGroupByFilter<PointDataTree, BBoxFilter>(tree, "bbox", filter2);
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "bbox"), Index64(3));
+        GroupFilter filter3("bbox", tree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, filter3), Index64(3));
     }
 
     { // first point filter and bbox filter (intersection of the above two filters)
         appendGroup(tree, "first_bbox");
 
         CPPUNIT_ASSERT_EQUAL(pointCount(tree), Index64(6));
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "first_bbox"), Index64(0));
+        GroupFilter filter("first_bbox", tree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, filter), Index64(0));
 
         using FirstBBoxFilter = BinaryFilter<FirstFilter, BBoxFilter>;
 
         FirstFilter firstFilter;
         BBoxFilter bboxFilter(*transform, bbox);
-        FirstBBoxFilter filter(firstFilter, bboxFilter);
+        FirstBBoxFilter filter2(firstFilter, bboxFilter);
 
-        setGroupByFilter<PointDataTree, FirstBBoxFilter>(tree, "first_bbox", filter);
+        setGroupByFilter<PointDataTree, FirstBBoxFilter>(tree, "first_bbox", filter2);
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(tree, "first_bbox"), Index64(1));
+        GroupFilter filter3("first_bbox", tree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(tree, filter3), Index64(1));
 
         std::vector<Vec3f> positions;
 
@@ -666,7 +682,8 @@ TestPointGroup::testFilter()
 
         setGroupByRandomTarget(newTree, "random_maximum", target);
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(newTree, "random_maximum"), target);
+        GroupFilter filter("random_maximum", newTree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(newTree, filter), target);
 
         // random - percentage
 
@@ -674,7 +691,8 @@ TestPointGroup::testFilter()
 
         setGroupByRandomPercentage(newTree, "random_percentage", 33.333333f);
 
-        CPPUNIT_ASSERT_EQUAL(groupPointCount(newTree, "random_percentage"), Index64(1000));
+        GroupFilter filter2("random_percentage", newTree.cbeginLeaf()->attributeSet());
+        CPPUNIT_ASSERT_EQUAL(pointCount(newTree, filter2), Index64(1000));
     }
 }
 

--- a/openvdb/unittest/TestPointMask.cc
+++ b/openvdb/unittest/TestPointMask.cc
@@ -114,12 +114,16 @@ TestPointMask::testMask()
     std::vector<std::string> excludeGroups;
 
     { // convert in turn "test" and not "test"
-        auto mask = convertPointsToMask(*points, includeGroups, excludeGroups);
+        MultiGroupFilter filter(includeGroups, excludeGroups,
+            points->tree().cbeginLeaf()->attributeSet());
+        auto mask = convertPointsToMask(*points, filter);
 
         CPPUNIT_ASSERT_EQUAL(points->tree().activeVoxelCount(), Index64(4));
         CPPUNIT_ASSERT_EQUAL(mask->tree().activeVoxelCount(), Index64(1));
 
-        mask = convertPointsToMask(*points, excludeGroups, includeGroups);
+        MultiGroupFilter filter2(excludeGroups, includeGroups,
+            points->tree().cbeginLeaf()->attributeSet());
+        mask = convertPointsToMask(*points, filter2);
 
         CPPUNIT_ASSERT_EQUAL(mask->tree().activeVoxelCount(), Index64(3));
     }
@@ -133,11 +137,15 @@ TestPointMask::testMask()
 
         CPPUNIT_ASSERT_EQUAL(mask->tree().activeVoxelCount(), Index64(2));
 
-        mask = convertPointsToMask(*points, *newTransform, includeGroups, excludeGroups);
+        MultiGroupFilter filter(includeGroups, excludeGroups,
+            points->tree().cbeginLeaf()->attributeSet());
+        mask = convertPointsToMask(*points, *newTransform, filter);
 
         CPPUNIT_ASSERT_EQUAL(mask->tree().activeVoxelCount(), Index64(1));
 
-        mask = convertPointsToMask(*points, *newTransform, excludeGroups, includeGroups);
+        MultiGroupFilter filter2(excludeGroups, includeGroups,
+            points->tree().cbeginLeaf()->attributeSet());
+        mask = convertPointsToMask(*points, *newTransform, filter2);
 
         CPPUNIT_ASSERT_EQUAL(mask->tree().activeVoxelCount(), Index64(2));
     }

--- a/openvdb_houdini/houdini/GR_PrimVDBPoints.cc
+++ b/openvdb_houdini/houdini/GR_PrimVDBPoints.cc
@@ -871,9 +871,14 @@ GR_PrimVDBPoints::updatePosBuffer(RE_Render* r,
 
     // count up total points ignoring any leaf nodes that are out of core
 
-    int numPoints = static_cast<int>(useGroup ?
-        groupPointCount(tree, groupName, /*inCoreOnly=*/true) :
-        pointCount(tree, /*inCoreOnly=*/true));
+    int numPoints = 0;
+    if (useGroup) {
+        GroupFilter filter(groupName, iter->attributeSet());
+        numPoints = static_cast<int>(pointCount(tree, filter, /*inCoreOnly=*/true));
+    } else {
+        NullFilter filter;
+        numPoints = static_cast<int>(pointCount(tree, filter, /*inCoreOnly=*/true));
+    }
 
     if (numPoints == 0)    return;
 

--- a/openvdb_houdini/houdini/GR_PrimVDBPoints.cc
+++ b/openvdb_houdini/houdini/GR_PrimVDBPoints.cc
@@ -907,16 +907,16 @@ GR_PrimVDBPoints::updatePosBuffer(RE_Render* r,
         std::vector<Name> excludeGroups;
         if (useGroup)   includeGroups.push_back(groupName);
 
-        std::vector<Index64> pointOffsets;
-        getPointOffsets(pointOffsets, grid.tree(),
-                        includeGroups, excludeGroups, /*inCoreOnly=*/true);
+        MultiGroupFilter filter(includeGroups, excludeGroups, iter->attributeSet());
+
+        std::vector<Index64> offsets;
+        pointOffsets(offsets, grid.tree(), filter, /*inCoreOnly=*/true);
 
         UT_UniquePtr<UT_Vector3H[]> pdata(new UT_Vector3H[numPoints]);
 
         PositionAttribute positionAttribute(pdata.get(), mCentroid, static_cast<Index>(stride));
-        convertPointDataGridPosition(positionAttribute, grid, pointOffsets,
-                                    /*startOffset=*/ 0, includeGroups, excludeGroups,
-                                    /*inCoreOnly=*/true);
+        convertPointDataGridPosition(positionAttribute, grid, offsets,
+                                    /*startOffset=*/ 0, filter, /*inCoreOnly=*/true);
 
         const int maxVertexSize = RE_OGLBuffer::getMaxVertexArraySize(r);
 
@@ -1178,14 +1178,16 @@ GR_PrimVDBPoints::updateVec3Buffer( RE_Render* r,
         std::vector<Name> excludeGroups;
         if (useGroup)   includeGroups.push_back(groupName);
 
-        std::vector<Index64> pointOffsets;
-        getPointOffsets(pointOffsets, grid.tree(), includeGroups, excludeGroups, /*inCoreOnly=*/true);
+        MultiGroupFilter filter(includeGroups, excludeGroups, iter->attributeSet());
+
+        std::vector<Index64> offsets;
+        pointOffsets(offsets, grid.tree(), filter, /*inCoreOnly=*/true);
 
         if (type == "vec3s") {
             VectorAttribute<Vec3f> typedAttribute(data.get());
-            convertPointDataGridAttribute(typedAttribute, grid.tree(), pointOffsets,
+            convertPointDataGridAttribute(typedAttribute, grid.tree(), offsets,
                 /*startOffset=*/ 0, static_cast<unsigned>(index), /*stride=*/1,
-                includeGroups, excludeGroups, /*inCoreOnly=*/true);
+                filter, /*inCoreOnly=*/true);
         }
 
         const int maxVertexSize = RE_OGLBuffer::getMaxVertexArraySize(r);

--- a/openvdb_houdini/houdini/PointUtils.cc
+++ b/openvdb_houdini/houdini/PointUtils.cc
@@ -1710,7 +1710,8 @@ pointDataGridSpecificInfoText(std::ostream& infoStr, const GridBase& grid)
                 infoStr << "out-of-core";
             }
             else {
-                infoStr << util::formattedInt(groupPointCount(pointDataTree, it->first));
+                GroupFilter filter(it->first, iter->attributeSet());
+                infoStr << util::formattedInt(pointCount(pointDataTree, filter));
             }
 
             infoStr << ")";

--- a/openvdb_houdini/houdini/PointUtils.cc
+++ b/openvdb_houdini/houdini/PointUtils.cc
@@ -1115,16 +1115,16 @@ convertPointDataGridToHoudini(
     std::sort(sortedAttributes.begin(), sortedAttributes.end());
 
     // obtain cumulative point offsets and total points
-    std::vector<Index64> pointOffsets;
-    const Index64 total = getPointOffsets(pointOffsets, tree, includeGroups, excludeGroups,
-        inCoreOnly);
+    std::vector<Index64> offsets;
+    MultiGroupFilter filter(includeGroups, excludeGroups, leafIter->attributeSet());
+    const Index64 total = pointOffsets(offsets, tree, filter, inCoreOnly);
 
     // a block's global offset is needed to transform its point offsets to global offsets
     const Index64 startOffset = detail.appendPointBlock(total);
 
     HoudiniWriteAttribute<Vec3f> positionAttribute(*detail.getP());
-    convertPointDataGridPosition(positionAttribute, grid, pointOffsets, startOffset, includeGroups,
-        excludeGroups, inCoreOnly);
+    convertPointDataGridPosition(positionAttribute, grid, offsets, startOffset,
+        filter, inCoreOnly);
 
     // add other point attributes to the hdk detail
     const AttributeSet::Descriptor::NameToPosMap& nameToPosMap = descriptor.map();
@@ -1206,83 +1206,83 @@ convertPointDataGridToHoudini(
 
         if (valueType == "string") {
             HoudiniWriteAttribute<Name> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "bool") {
             HoudiniWriteAttribute<bool> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "int16") {
             HoudiniWriteAttribute<int16_t> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "int32") {
             HoudiniWriteAttribute<int32_t> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "int64") {
             HoudiniWriteAttribute<int64_t> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "float") {
             HoudiniWriteAttribute<float> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "double") {
             HoudiniWriteAttribute<double> attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "vec3i") {
             HoudiniWriteAttribute<Vec3<int> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "vec3s") {
             HoudiniWriteAttribute<Vec3<float> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "vec3d") {
             HoudiniWriteAttribute<Vec3<double> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "quats") {
             HoudiniWriteAttribute<Quat<float> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "quatd") {
             HoudiniWriteAttribute<Quat<double> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "mat3s") {
             HoudiniWriteAttribute<Mat3<float> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "mat3d") {
             HoudiniWriteAttribute<Mat3<double> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "mat4s") {
             HoudiniWriteAttribute<Mat4<float> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else if (valueType == "mat4d") {
             HoudiniWriteAttribute<Mat4<double> > attribute(*attributeRef.getAttribute());
-            convertPointDataGridAttribute(attribute, tree, pointOffsets, startOffset, index, stride,
-                includeGroups, excludeGroups, inCoreOnly);
+            convertPointDataGridAttribute(attribute, tree, offsets, startOffset, index, stride,
+                filter, inCoreOnly);
         }
         else {
             throw std::runtime_error("Unknown Attribute Type for Conversion: " + valueType);
@@ -1304,8 +1304,7 @@ convertPointDataGridToHoudini(
             attributeSet.groupIndex(name);
 
         HoudiniGroup group(*pointGroup, startOffset, total);
-        convertPointDataGridGroup(group, tree, pointOffsets, startOffset, index,
-            includeGroups, excludeGroups, inCoreOnly);
+        convertPointDataGridGroup(group, tree, offsets, startOffset, index, filter, inCoreOnly);
     }
 }
 

--- a/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
+++ b/openvdb_houdini/houdini/SOP_OpenVDB_Points_Convert.cc
@@ -787,13 +787,19 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Convert)::cookVDBSop(OP
 
                     if (conversion == MODE_GENERATE_MASK) {
                         openvdb::BoolGrid::Ptr maskGrid;
-                        if (transform) {
-                            maskGrid = openvdb::points::convertPointsToMask(
-                                *grid, *transform, includeGroups, excludeGroups);
-                        }
-                        else {
-                            maskGrid = openvdb::points::convertPointsToMask(
-                                *grid, includeGroups, excludeGroups);
+                        auto leaf = grid->tree().cbeginLeaf();
+                        if (leaf) {
+                            MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+                            if (transform) {
+                                maskGrid = openvdb::points::convertPointsToMask(
+                                    *grid, *transform, filter);
+                            }
+                            else {
+                                maskGrid = openvdb::points::convertPointsToMask(
+                                    *grid, filter);
+                            }
+                        } else {
+                            maskGrid = openvdb::BoolGrid::create();
                         }
 
                         const std::string customName = evalStdString("maskname", time);
@@ -808,13 +814,20 @@ VDB_NODE_OR_CACHE(VDB_COMPILABLE_SOP, SOP_OpenVDB_Points_Convert)::cookVDBSop(OP
                     }
                     else {
                         openvdb::Int32Grid::Ptr countGrid;
-                        if (transform) {
-                            countGrid = openvdb::points::pointCountGrid(
-                                *grid, *transform, includeGroups, excludeGroups);
+                        auto leaf = grid->tree().cbeginLeaf();
+                        if (leaf) {
+                            MultiGroupFilter filter(includeGroups, excludeGroups, leaf->attributeSet());
+                            if (transform) {
+                                countGrid = openvdb::points::pointCountGrid(
+                                    *grid, *transform, filter);
+                            }
+                            else {
+                                countGrid = openvdb::points::pointCountGrid(
+                                    *grid, filter);
+                            }
                         }
                         else {
-                            countGrid = openvdb::points::pointCountGrid(
-                                *grid, includeGroups, excludeGroups);
+                            countGrid = openvdb::Int32Grid::create();
                         }
 
                         const std::string customName = evalStdString("maskname", time);

--- a/openvdb_houdini/houdini/VRAY_OpenVDB_Points.cc
+++ b/openvdb_houdini/houdini/VRAY_OpenVDB_Points.cc
@@ -272,24 +272,16 @@ struct PopulateColorFromVelocityOp {
             const bool uniform = velocityHandle->isUniform();
             const Vec3f uniformColor = getColorFromRamp(velocityHandle->get(0));
 
-            if (!mIncludeGroups.empty() || !mExcludeGroups.empty()) {
-
-                MultiGroupFilter filter(mIncludeGroups, mExcludeGroups, leaf.attributeSet());
-                auto iter = leaf.beginIndexOn(filter);
-
-                for (; iter; ++iter) {
-
+            MultiGroupFilter filter(mIncludeGroups, mExcludeGroups, leaf.attributeSet());
+            if (filter.state() == points::index::ALL) {
+                for (auto iter = leaf.beginIndexOn(); iter; ++iter) {
                     Vec3f color = uniform ?
                         uniformColor : getColorFromRamp(velocityHandle->get(*iter));
                     colorHandle->set(*iter, color);
                 }
             }
             else {
-
-                auto iter = leaf.beginIndexOn();
-
-                for (; iter; ++iter) {
-
+                for (auto iter = leaf.beginIndexOn(filter); iter; ++iter) {
                     Vec3f color = uniform ?
                         uniformColor : getColorFromRamp(velocityHandle->get(*iter));
                     colorHandle->set(*iter, color);


### PR DESCRIPTION
* Adding extra state() methods to index filter interface to improve optimization opportunities
* Adding active and inactive value mask index filters
* Switching include/exclude groups API to instead use explicit filtering
* Refactoring and simplifying of point count API
* Computing cumulative per-leaf point offsets is now parallelized